### PR TITLE
Add `MuteRestrictedErrOnKickFromPublic` option for Slack conversations

### DIFF
--- a/pkg/adapters/slack/conversation/conversation_internal_test.go
+++ b/pkg/adapters/slack/conversation/conversation_internal_test.go
@@ -116,8 +116,8 @@ func TestConversation_Remove(t *testing.T) {
 		adapter.client = slackClient
 		adapter.cache = map[string]string{"foo@email": "foo", "bar@email": "bar"}
 
-		slackClient.EXPECT().KickUserFromConversation("test", "foo").Return(restrictedAction)
-		slackClient.EXPECT().KickUserFromConversation("test", "bar").Return(restrictedAction)
+		slackClient.EXPECT().KickUserFromConversation("test", "foo").Maybe().Return(restrictedAction)
+		slackClient.EXPECT().KickUserFromConversation("test", "bar").Maybe().Return(restrictedAction)
 
 		adapter.MuteRestrictedErrOnKickFromPublic = false
 


### PR DESCRIPTION
Slack can be configured to prevent non-admins from being able to kick from public channels. If this is the case, a single failure will cancel the entire `SyncWith` job. Setting this value to true will mute the error and continue processing.