### PR TITLE
Fix Slack usergroup

### DIFF
--- a/internal/mocks/iSlackUserGroup.go
+++ b/internal/mocks/iSlackUserGroup.go
@@ -3,6 +3,8 @@
 package mocks
 
 import (
+	context "context"
+
 	slack "github.com/slack-go/slack"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -20,101 +22,13 @@ func (_m *ISlackUserGroup) EXPECT() *ISlackUserGroup_Expecter {
 	return &ISlackUserGroup_Expecter{mock: &_m.Mock}
 }
 
-// DisableUserGroup provides a mock function with given fields: userGroup
-func (_m *ISlackUserGroup) DisableUserGroup(userGroup string) (slack.UserGroup, error) {
-	ret := _m.Called(userGroup)
-
-	var r0 slack.UserGroup
-	if rf, ok := ret.Get(0).(func(string) slack.UserGroup); ok {
-		r0 = rf(userGroup)
-	} else {
-		r0 = ret.Get(0).(slack.UserGroup)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(userGroup)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ISlackUserGroup_DisableUserGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DisableUserGroup'
-type ISlackUserGroup_DisableUserGroup_Call struct {
-	*mock.Call
-}
-
-// DisableUserGroup is a helper method to define mock.On call
-//   - userGroup string
-func (_e *ISlackUserGroup_Expecter) DisableUserGroup(userGroup interface{}) *ISlackUserGroup_DisableUserGroup_Call {
-	return &ISlackUserGroup_DisableUserGroup_Call{Call: _e.mock.On("DisableUserGroup", userGroup)}
-}
-
-func (_c *ISlackUserGroup_DisableUserGroup_Call) Run(run func(userGroup string)) *ISlackUserGroup_DisableUserGroup_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *ISlackUserGroup_DisableUserGroup_Call) Return(_a0 slack.UserGroup, _a1 error) *ISlackUserGroup_DisableUserGroup_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-// EnableUserGroup provides a mock function with given fields: userGroup
-func (_m *ISlackUserGroup) EnableUserGroup(userGroup string) (slack.UserGroup, error) {
-	ret := _m.Called(userGroup)
-
-	var r0 slack.UserGroup
-	if rf, ok := ret.Get(0).(func(string) slack.UserGroup); ok {
-		r0 = rf(userGroup)
-	} else {
-		r0 = ret.Get(0).(slack.UserGroup)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(userGroup)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ISlackUserGroup_EnableUserGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnableUserGroup'
-type ISlackUserGroup_EnableUserGroup_Call struct {
-	*mock.Call
-}
-
-// EnableUserGroup is a helper method to define mock.On call
-//   - userGroup string
-func (_e *ISlackUserGroup_Expecter) EnableUserGroup(userGroup interface{}) *ISlackUserGroup_EnableUserGroup_Call {
-	return &ISlackUserGroup_EnableUserGroup_Call{Call: _e.mock.On("EnableUserGroup", userGroup)}
-}
-
-func (_c *ISlackUserGroup_EnableUserGroup_Call) Run(run func(userGroup string)) *ISlackUserGroup_EnableUserGroup_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *ISlackUserGroup_EnableUserGroup_Call) Return(_a0 slack.UserGroup, _a1 error) *ISlackUserGroup_EnableUserGroup_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-// GetUserByEmail provides a mock function with given fields: email
-func (_m *ISlackUserGroup) GetUserByEmail(email string) (*slack.User, error) {
-	ret := _m.Called(email)
+// GetUserByEmailContext provides a mock function with given fields: ctx, email
+func (_m *ISlackUserGroup) GetUserByEmailContext(ctx context.Context, email string) (*slack.User, error) {
+	ret := _m.Called(ctx, email)
 
 	var r0 *slack.User
-	if rf, ok := ret.Get(0).(func(string) *slack.User); ok {
-		r0 = rf(email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *slack.User); ok {
+		r0 = rf(ctx, email)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*slack.User)
@@ -122,8 +36,8 @@ func (_m *ISlackUserGroup) GetUserByEmail(email string) (*slack.User, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(email)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, email)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -131,36 +45,37 @@ func (_m *ISlackUserGroup) GetUserByEmail(email string) (*slack.User, error) {
 	return r0, r1
 }
 
-// ISlackUserGroup_GetUserByEmail_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserByEmail'
-type ISlackUserGroup_GetUserByEmail_Call struct {
+// ISlackUserGroup_GetUserByEmailContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserByEmailContext'
+type ISlackUserGroup_GetUserByEmailContext_Call struct {
 	*mock.Call
 }
 
-// GetUserByEmail is a helper method to define mock.On call
+// GetUserByEmailContext is a helper method to define mock.On call
+//   - ctx context.Context
 //   - email string
-func (_e *ISlackUserGroup_Expecter) GetUserByEmail(email interface{}) *ISlackUserGroup_GetUserByEmail_Call {
-	return &ISlackUserGroup_GetUserByEmail_Call{Call: _e.mock.On("GetUserByEmail", email)}
+func (_e *ISlackUserGroup_Expecter) GetUserByEmailContext(ctx interface{}, email interface{}) *ISlackUserGroup_GetUserByEmailContext_Call {
+	return &ISlackUserGroup_GetUserByEmailContext_Call{Call: _e.mock.On("GetUserByEmailContext", ctx, email)}
 }
 
-func (_c *ISlackUserGroup_GetUserByEmail_Call) Run(run func(email string)) *ISlackUserGroup_GetUserByEmail_Call {
+func (_c *ISlackUserGroup_GetUserByEmailContext_Call) Run(run func(ctx context.Context, email string)) *ISlackUserGroup_GetUserByEmailContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
 
-func (_c *ISlackUserGroup_GetUserByEmail_Call) Return(_a0 *slack.User, _a1 error) *ISlackUserGroup_GetUserByEmail_Call {
+func (_c *ISlackUserGroup_GetUserByEmailContext_Call) Return(_a0 *slack.User, _a1 error) *ISlackUserGroup_GetUserByEmailContext_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-// GetUserGroupMembers provides a mock function with given fields: userGroup
-func (_m *ISlackUserGroup) GetUserGroupMembers(userGroup string) ([]string, error) {
-	ret := _m.Called(userGroup)
+// GetUserGroupMembersContext provides a mock function with given fields: ctx, userGroup
+func (_m *ISlackUserGroup) GetUserGroupMembersContext(ctx context.Context, userGroup string) ([]string, error) {
+	ret := _m.Called(ctx, userGroup)
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func(string) []string); ok {
-		r0 = rf(userGroup)
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = rf(ctx, userGroup)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -168,8 +83,8 @@ func (_m *ISlackUserGroup) GetUserGroupMembers(userGroup string) ([]string, erro
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(userGroup)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userGroup)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -177,42 +92,44 @@ func (_m *ISlackUserGroup) GetUserGroupMembers(userGroup string) ([]string, erro
 	return r0, r1
 }
 
-// ISlackUserGroup_GetUserGroupMembers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserGroupMembers'
-type ISlackUserGroup_GetUserGroupMembers_Call struct {
+// ISlackUserGroup_GetUserGroupMembersContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserGroupMembersContext'
+type ISlackUserGroup_GetUserGroupMembersContext_Call struct {
 	*mock.Call
 }
 
-// GetUserGroupMembers is a helper method to define mock.On call
+// GetUserGroupMembersContext is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userGroup string
-func (_e *ISlackUserGroup_Expecter) GetUserGroupMembers(userGroup interface{}) *ISlackUserGroup_GetUserGroupMembers_Call {
-	return &ISlackUserGroup_GetUserGroupMembers_Call{Call: _e.mock.On("GetUserGroupMembers", userGroup)}
+func (_e *ISlackUserGroup_Expecter) GetUserGroupMembersContext(ctx interface{}, userGroup interface{}) *ISlackUserGroup_GetUserGroupMembersContext_Call {
+	return &ISlackUserGroup_GetUserGroupMembersContext_Call{Call: _e.mock.On("GetUserGroupMembersContext", ctx, userGroup)}
 }
 
-func (_c *ISlackUserGroup_GetUserGroupMembers_Call) Run(run func(userGroup string)) *ISlackUserGroup_GetUserGroupMembers_Call {
+func (_c *ISlackUserGroup_GetUserGroupMembersContext_Call) Run(run func(ctx context.Context, userGroup string)) *ISlackUserGroup_GetUserGroupMembersContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
 
-func (_c *ISlackUserGroup_GetUserGroupMembers_Call) Return(_a0 []string, _a1 error) *ISlackUserGroup_GetUserGroupMembers_Call {
+func (_c *ISlackUserGroup_GetUserGroupMembersContext_Call) Return(_a0 []string, _a1 error) *ISlackUserGroup_GetUserGroupMembersContext_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-// GetUsersInfo provides a mock function with given fields: users
-func (_m *ISlackUserGroup) GetUsersInfo(users ...string) (*[]slack.User, error) {
+// GetUsersInfoContext provides a mock function with given fields: ctx, users
+func (_m *ISlackUserGroup) GetUsersInfoContext(ctx context.Context, users ...string) (*[]slack.User, error) {
 	_va := make([]interface{}, len(users))
 	for _i := range users {
 		_va[_i] = users[_i]
 	}
 	var _ca []interface{}
+	_ca = append(_ca, ctx)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 *[]slack.User
-	if rf, ok := ret.Get(0).(func(...string) *[]slack.User); ok {
-		r0 = rf(users...)
+	if rf, ok := ret.Get(0).(func(context.Context, ...string) *[]slack.User); ok {
+		r0 = rf(ctx, users...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*[]slack.User)
@@ -220,8 +137,8 @@ func (_m *ISlackUserGroup) GetUsersInfo(users ...string) (*[]slack.User, error) 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(...string) error); ok {
-		r1 = rf(users...)
+	if rf, ok := ret.Get(1).(func(context.Context, ...string) error); ok {
+		r1 = rf(ctx, users...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -229,50 +146,51 @@ func (_m *ISlackUserGroup) GetUsersInfo(users ...string) (*[]slack.User, error) 
 	return r0, r1
 }
 
-// ISlackUserGroup_GetUsersInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUsersInfo'
-type ISlackUserGroup_GetUsersInfo_Call struct {
+// ISlackUserGroup_GetUsersInfoContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUsersInfoContext'
+type ISlackUserGroup_GetUsersInfoContext_Call struct {
 	*mock.Call
 }
 
-// GetUsersInfo is a helper method to define mock.On call
+// GetUsersInfoContext is a helper method to define mock.On call
+//   - ctx context.Context
 //   - users ...string
-func (_e *ISlackUserGroup_Expecter) GetUsersInfo(users ...interface{}) *ISlackUserGroup_GetUsersInfo_Call {
-	return &ISlackUserGroup_GetUsersInfo_Call{Call: _e.mock.On("GetUsersInfo",
-		append([]interface{}{}, users...)...)}
+func (_e *ISlackUserGroup_Expecter) GetUsersInfoContext(ctx interface{}, users ...interface{}) *ISlackUserGroup_GetUsersInfoContext_Call {
+	return &ISlackUserGroup_GetUsersInfoContext_Call{Call: _e.mock.On("GetUsersInfoContext",
+		append([]interface{}{ctx}, users...)...)}
 }
 
-func (_c *ISlackUserGroup_GetUsersInfo_Call) Run(run func(users ...string)) *ISlackUserGroup_GetUsersInfo_Call {
+func (_c *ISlackUserGroup_GetUsersInfoContext_Call) Run(run func(ctx context.Context, users ...string)) *ISlackUserGroup_GetUsersInfoContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]string, len(args)-0)
-		for i, a := range args[0:] {
+		variadicArgs := make([]string, len(args)-1)
+		for i, a := range args[1:] {
 			if a != nil {
 				variadicArgs[i] = a.(string)
 			}
 		}
-		run(variadicArgs...)
+		run(args[0].(context.Context), variadicArgs...)
 	})
 	return _c
 }
 
-func (_c *ISlackUserGroup_GetUsersInfo_Call) Return(_a0 *[]slack.User, _a1 error) *ISlackUserGroup_GetUsersInfo_Call {
+func (_c *ISlackUserGroup_GetUsersInfoContext_Call) Return(_a0 *[]slack.User, _a1 error) *ISlackUserGroup_GetUsersInfoContext_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-// UpdateUserGroupMembers provides a mock function with given fields: userGroup, members
-func (_m *ISlackUserGroup) UpdateUserGroupMembers(userGroup string, members string) (slack.UserGroup, error) {
-	ret := _m.Called(userGroup, members)
+// UpdateUserGroupMembersContext provides a mock function with given fields: ctx, userGroup, members
+func (_m *ISlackUserGroup) UpdateUserGroupMembersContext(ctx context.Context, userGroup string, members string) (slack.UserGroup, error) {
+	ret := _m.Called(ctx, userGroup, members)
 
 	var r0 slack.UserGroup
-	if rf, ok := ret.Get(0).(func(string, string) slack.UserGroup); ok {
-		r0 = rf(userGroup, members)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) slack.UserGroup); ok {
+		r0 = rf(ctx, userGroup, members)
 	} else {
 		r0 = ret.Get(0).(slack.UserGroup)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(userGroup, members)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, userGroup, members)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -280,26 +198,27 @@ func (_m *ISlackUserGroup) UpdateUserGroupMembers(userGroup string, members stri
 	return r0, r1
 }
 
-// ISlackUserGroup_UpdateUserGroupMembers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateUserGroupMembers'
-type ISlackUserGroup_UpdateUserGroupMembers_Call struct {
+// ISlackUserGroup_UpdateUserGroupMembersContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateUserGroupMembersContext'
+type ISlackUserGroup_UpdateUserGroupMembersContext_Call struct {
 	*mock.Call
 }
 
-// UpdateUserGroupMembers is a helper method to define mock.On call
+// UpdateUserGroupMembersContext is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userGroup string
 //   - members string
-func (_e *ISlackUserGroup_Expecter) UpdateUserGroupMembers(userGroup interface{}, members interface{}) *ISlackUserGroup_UpdateUserGroupMembers_Call {
-	return &ISlackUserGroup_UpdateUserGroupMembers_Call{Call: _e.mock.On("UpdateUserGroupMembers", userGroup, members)}
+func (_e *ISlackUserGroup_Expecter) UpdateUserGroupMembersContext(ctx interface{}, userGroup interface{}, members interface{}) *ISlackUserGroup_UpdateUserGroupMembersContext_Call {
+	return &ISlackUserGroup_UpdateUserGroupMembersContext_Call{Call: _e.mock.On("UpdateUserGroupMembersContext", ctx, userGroup, members)}
 }
 
-func (_c *ISlackUserGroup_UpdateUserGroupMembers_Call) Run(run func(userGroup string, members string)) *ISlackUserGroup_UpdateUserGroupMembers_Call {
+func (_c *ISlackUserGroup_UpdateUserGroupMembersContext_Call) Run(run func(ctx context.Context, userGroup string, members string)) *ISlackUserGroup_UpdateUserGroupMembersContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
 
-func (_c *ISlackUserGroup_UpdateUserGroupMembers_Call) Return(_a0 slack.UserGroup, _a1 error) *ISlackUserGroup_UpdateUserGroupMembers_Call {
+func (_c *ISlackUserGroup_UpdateUserGroupMembersContext_Call) Return(_a0 slack.UserGroup, _a1 error) *ISlackUserGroup_UpdateUserGroupMembersContext_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }

--- a/pkg/adapters/slack/conversation/README.md
+++ b/pkg/adapters/slack/conversation/README.md
@@ -1,6 +1,11 @@
 # Slack Conversation adapter for Go Sync
 This adapter synchronises email addresses with a Slack conversation.
 
+## Warning
+The Slack usergroup API doesn't allow a usergroup to have no members. If this behaviour is expected, we recommend
+setting `adapter.MuteGroupCannotBeEmpty = true` to mute the error. No members will be removed, but Go Sync will continue
+processing.
+
 ## Requirements
 In order to synchronise with Slack, you'll need to [create a Slack app](https://api.slack.com/authentication/basics)
 with the following OAuth permissions:


### PR DESCRIPTION
The enable/disable usergroup functionality doesn't work as expected, and it prevents the adapter from working entirely. I've removed this functionality, and instead added an option to mute errors if they're expected.