### PR TITLE
Add operating modes and update adapter caches

### DIFF
--- a/pkg/adapters/opsgenie/oncall/oncall.go
+++ b/pkg/adapters/opsgenie/oncall/oncall.go
@@ -2,7 +2,6 @@ package oncall
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,14 +10,12 @@ import (
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/schedule"
 	"github.com/ovotech/go-sync/internal/types"
+	gosyncerrors "github.com/ovotech/go-sync/pkg/errors"
 	"github.com/ovotech/go-sync/pkg/ports"
 )
 
 // Ensure the adapter type fully satisfies the ports.Adapter interface.
 var _ ports.Adapter = &OnCall{}
-
-// ErrNotImplemented is returned if this adapter is used as a destination.
-var ErrNotImplemented = errors.New("not implemented - on-call is readonly")
 
 type iOpsgenieSchedule interface {
 	GetOnCalls(context context.Context, request *schedule.GetOnCallsRequest) (*schedule.GetOnCallsResult, error)
@@ -78,10 +75,10 @@ func (o *OnCall) Get(ctx context.Context) ([]string, error) {
 
 // Add is not supported, as the on-call is readonly.
 func (o *OnCall) Add(_ context.Context, _ []string) error {
-	return ErrNotImplemented
+	return gosyncerrors.ErrReadOnly
 }
 
 // Remove is not supported, as the on-call is readonly.
 func (o *OnCall) Remove(_ context.Context, _ []string) error {
-	return ErrNotImplemented
+	return gosyncerrors.ErrReadOnly
 }

--- a/pkg/adapters/opsgenie/oncall/oncall_internal_test.go
+++ b/pkg/adapters/opsgenie/oncall/oncall_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/schedule"
 	"github.com/ovotech/go-sync/internal/mocks"
+	gosyncerrors "github.com/ovotech/go-sync/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -97,7 +98,7 @@ func TestOnCall_Add(t *testing.T) {
 
 	err := adapter.Add(ctx, []string{"example@bar.com"})
 
-	assert.ErrorIs(t, err, ErrNotImplemented)
+	assert.ErrorIs(t, err, gosyncerrors.ErrReadOnly)
 	assert.Zero(t, scheduleClient.Calls)
 }
 
@@ -109,6 +110,6 @@ func TestOnCall_Remove(t *testing.T) {
 
 	err := adapter.Remove(ctx, []string{"example@bar.com"})
 
-	assert.ErrorIs(t, err, ErrNotImplemented)
+	assert.ErrorIs(t, err, gosyncerrors.ErrReadOnly)
 	assert.Zero(t, scheduleClient.Calls)
 }

--- a/pkg/adapters/slack/conversation/conversation_internal_test.go
+++ b/pkg/adapters/slack/conversation/conversation_internal_test.go
@@ -74,7 +74,6 @@ func TestConversation_Add(t *testing.T) {
 	err := adapter.Add(context.TODO(), []string{"foo@email", "bar@email"})
 
 	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{"foo@email": "foo", "bar@email": "bar"}, adapter.cache)
 }
 
 func TestConversation_Remove(t *testing.T) {
@@ -96,7 +95,6 @@ func TestConversation_Remove(t *testing.T) {
 		err := adapter.Remove(ctx, []string{"foo@email", "bar@email"})
 
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]string{}, adapter.cache)
 	})
 
 	t.Run("Restricted kick from public conversation", func(t *testing.T) {

--- a/pkg/adapters/slack/usergroup/usergroup_internal_test.go
+++ b/pkg/adapters/slack/usergroup/usergroup_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ovotech/go-sync/internal/mocks"
+	gosyncerrors "github.com/ovotech/go-sync/pkg/errors"
 	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -64,7 +65,7 @@ func TestUserGroup_Add(t *testing.T) {
 		err := adapter.Add(ctx, []string{"foo", "bar"})
 
 		assert.Error(t, err)
-		assert.ErrorIs(t, err, ErrCacheEmpty)
+		assert.ErrorIs(t, err, gosyncerrors.ErrCacheEmpty)
 	})
 
 	t.Run("Add accounts", func(t *testing.T) {
@@ -87,9 +88,6 @@ func TestUserGroup_Add(t *testing.T) {
 		err := adapter.Add(ctx, []string{"fizz@email", "buzz@email"})
 
 		assert.NoError(t, err)
-		assert.Equal(t, adapter.cache, map[string]string{
-			"foo@email": "foo", "bar@email": "bar", "fizz@email": "fizz", "buzz@email": "buzz",
-		})
 	})
 }
 
@@ -108,7 +106,7 @@ func TestUserGroup_Remove(t *testing.T) {
 		err := adapter.Remove(ctx, []string{"foo@email"})
 
 		assert.Error(t, err)
-		assert.ErrorIs(t, err, ErrCacheEmpty)
+		assert.ErrorIs(t, err, gosyncerrors.ErrCacheEmpty)
 	})
 
 	t.Run("Remove accounts", func(t *testing.T) {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,12 @@
+/*
+Package errors contains errors returned from Go Sync and adapters.
+*/
+package errors
+
+import "errors"
+
+// ErrCacheEmpty is returned if an adapter expects Get to be called before Add/Remove.
+var ErrCacheEmpty = errors.New("cache is empty, run Get first")
+
+// ErrReadOnly is returned for adapters that cannot Add/Remove, but have been set as a destination.
+var ErrReadOnly = errors.New("cannot perform action, adapter is readonly")

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -13,6 +13,19 @@ import (
 	"github.com/ovotech/go-sync/pkg/ports"
 )
 
+type operatingMode string
+
+const (
+	// AddOnly only runs add operations.
+	AddOnly operatingMode = "Add"
+	// RemoveOnly only runs remove operations.
+	RemoveOnly operatingMode = "Remove"
+	// RemoveAdd first removes things, then adds them.
+	RemoveAdd operatingMode = "RemoveAdd"
+	// AddRemove first adds things, then removes them.
+	AddRemove operatingMode = "AddRemove"
+)
+
 // generateHashMap takes a list of strings and returns a hashed map of { item => true }.
 func generateHashMap(i []string) map[string]bool {
 	out := map[string]bool{}
@@ -24,23 +37,21 @@ func generateHashMap(i []string) map[string]bool {
 }
 
 type Sync struct {
-	DryRun bool            // DryRun mode calculates membership, but doesn't add or remove.
-	Add    bool            // Perform Add operations.
-	Remove bool            // Perform Remove operations.
-	source ports.Adapter   // The source adapter.
-	cache  map[string]bool // cache prevents polling the source more than once.
-	logger types.Logger
+	DryRun        bool            // DryRun mode calculates membership, but doesn't add or remove.
+	OperatingMode operatingMode   // Change the order of Sync's operation. Default is RemoveAdd.
+	source        ports.Adapter   // The source adapter.
+	cache         map[string]bool // cache prevents polling the source more than once.
+	logger        types.Logger
 }
 
 // New creates a new Sync service.
 func New(source ports.Adapter, optsFn ...func(*Sync)) *Sync {
 	sync := &Sync{
-		DryRun: false,
-		Add:    true,
-		Remove: true,
-		source: source,
-		cache:  make(map[string]bool),
-		logger: log.New(os.Stderr, "[go-sync/sync] ", log.LstdFlags|log.Lshortfile|log.Lmsgprefix),
+		DryRun:        false,
+		OperatingMode: RemoveAdd,
+		source:        source,
+		cache:         make(map[string]bool),
+		logger:        log.New(os.Stderr, "[go-sync/sync] ", log.LstdFlags|log.Lshortfile|log.Lmsgprefix),
 	}
 
 	for _, fn := range optsFn {
@@ -101,42 +112,38 @@ func WithLogger(logger types.Logger) func(*Sync) {
 	}
 }
 
-// remove processes removing things from a destination service.
-func (s *Sync) remove(ctx context.Context, things []string, removeFn func(context.Context, []string) error) error {
-	thingsToRemove := s.getThingsToRemove(things)
+// perform processes adding/removing things from a destination service.
+func (s *Sync) perform(
+	ctx context.Context,
+	action string,
+	things []string,
+	diffFn func(things []string) []string,
+	executeFn func(context.Context, []string) error,
+) func() error {
+	return func() error {
+		s.logger.Printf("Processing things to %s\n", action)
 
-	if s.DryRun || !s.Remove {
-		s.logger.Printf("Would remove %s, but remove is disabled", thingsToRemove)
+		thingsToChange := diffFn(things)
+
+		if s.DryRun {
+			s.logger.Printf("Would %s %s, but running in dry run mode", action, thingsToChange)
+
+			return nil
+		}
+
+		if len(thingsToChange) == 0 {
+			return nil
+		}
+
+		s.logger.Printf("%s: %s", action, thingsToChange)
+
+		err := executeFn(ctx, thingsToChange)
+		if err != nil {
+			return fmt.Errorf("%s(%v) -> %w", action, things, err)
+		}
 
 		return nil
 	}
-
-	if len(thingsToRemove) == 0 {
-		return nil
-	}
-
-	s.logger.Printf("Removing %s", thingsToRemove)
-
-	return removeFn(ctx, thingsToRemove)
-}
-
-// add processes adding things to a destination service.
-func (s *Sync) add(ctx context.Context, things []string, removeFn func(context.Context, []string) error) error {
-	thingsToAdd := s.getThingsToAdd(things)
-
-	if s.DryRun || !s.Add {
-		s.logger.Printf("Would add %s, but add is disabled", thingsToAdd)
-
-		return nil
-	}
-
-	if len(thingsToAdd) == 0 {
-		return nil
-	}
-
-	s.logger.Printf("Adding %s", thingsToAdd)
-
-	return removeFn(ctx, thingsToAdd)
 }
 
 // SyncWith synchronises the destination service with the source service, adding & removing things as necessary.
@@ -155,18 +162,34 @@ func (s *Sync) SyncWith(ctx context.Context, adapter ports.Adapter) error {
 		return fmt.Errorf("sync.syncwith.get -> %w", err)
 	}
 
-	s.logger.Println("Processing things to remove")
+	operations := make([]func() error, 0, 2) //nolint:gomnd
 
-	err = s.remove(ctx, things, adapter.Remove)
-	if err != nil {
-		return fmt.Errorf("sync.syncwith.remove -> %w", err)
+	switch s.OperatingMode {
+	case AddOnly:
+		operations = []func() error{
+			s.perform(ctx, "add", things, s.getThingsToAdd, adapter.Add),
+		}
+	case RemoveOnly:
+		operations = []func() error{
+			s.perform(ctx, "remove", things, s.getThingsToRemove, adapter.Remove),
+		}
+	case RemoveAdd:
+		operations = []func() error{
+			s.perform(ctx, "remove", things, s.getThingsToRemove, adapter.Remove),
+			s.perform(ctx, "add", things, s.getThingsToAdd, adapter.Add),
+		}
+	case AddRemove:
+		operations = []func() error{
+			s.perform(ctx, "add", things, s.getThingsToAdd, adapter.Add),
+			s.perform(ctx, "remove", things, s.getThingsToRemove, adapter.Remove),
+		}
 	}
 
-	s.logger.Println("Processing things to add")
-
-	err = s.add(ctx, things, adapter.Add)
-	if err != nil {
-		return fmt.Errorf("sync.syncwith.add -> %w", err)
+	for _, fn := range operations {
+		err = fn()
+		if err != nil {
+			return fmt.Errorf("sync.syncwith.execute -> %w", err)
+		}
 	}
 
 	s.logger.Println("Finished sync")


### PR DESCRIPTION
This replaces the Add/Remove functionality with operating modes that allow users to customise the order of execution, and which actions are performed.