### PR TITLE
Remove cache invalidation as it was causing operations to fail

### DIFF
--- a/pkg/adapters/github/team/team.go
+++ b/pkg/adapters/github/team/team.go
@@ -170,8 +170,5 @@ func (t *Team) Remove(ctx context.Context, emails []string) error {
 
 	t.logger.Println("Finished removing accounts successfully")
 
-	// Empty the cache to force calling Get between Remove calls.
-	t.cache = nil
-
 	return nil
 }

--- a/pkg/adapters/slack/conversation/conversation.go
+++ b/pkg/adapters/slack/conversation/conversation.go
@@ -193,8 +193,5 @@ func (c *Conversation) Remove(_ context.Context, emails []string) error {
 
 	c.logger.Println("Finished removing accounts successfully")
 
-	// Empty the cache to force calling Get between Remove calls.
-	c.cache = nil
-
 	return nil
 }

--- a/pkg/adapters/slack/usergroup/usergroup.go
+++ b/pkg/adapters/slack/usergroup/usergroup.go
@@ -134,9 +134,6 @@ func (u *UserGroup) Add(ctx context.Context, emails []string) error {
 		return fmt.Errorf("slack.usergroup.add.updateusergroupmembers(%s) -> %w", u.userGroupName, err)
 	}
 
-	// Empty the cache to force calling Get between Add/Remove calls.
-	u.cache = nil
-
 	u.logger.Println("Finished adding accounts successfully")
 
 	return nil
@@ -179,9 +176,6 @@ func (u *UserGroup) Remove(ctx context.Context, emails []string) error {
 
 		return fmt.Errorf("slack.usergroup.remove.updateusergroupmembers(%s, ...) -> %w", u.userGroupName, err)
 	}
-
-	// Empty the cache to force calling Get between Add/Remove calls.
-	u.cache = nil
 
 	u.logger.Println("Finished removing accounts successfully")
 


### PR DESCRIPTION
After Add/Remove operations, it rapidly became unreliable to update the cache (and unnecessary as Get refreshes the cache should an adapter be reused). Clearing the cache after an operation (in theory) made sense, but Sync doesn't call Get between Add/Remove operations. 

I've removed the cache invalidation, and instead will leave it up to the end user to refresh the cache if they're using an adapter outside of Go Sync.