### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ func New() *MyAdapter {
 	return &MyAdapter {}
 }
 
-func (m *MyAdapter) Get() ([]string, error) {
+func (m *MyAdapter) Get(_ context.Context) ([]string, error) {
 	return nil, fmt.Errorf("myadapter.get -> %w", ErrNotImplemented)
 }
 


### PR DESCRIPTION
The example adapter in `CONTRIBUTING.md` should now match the `Adapter` interface correctly.