### PR TITLE
Rework Makefile to use dependencies, and sentinel file pattern

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           cache: true
 
       - name: make lint-fix
@@ -24,8 +25,9 @@ jobs:
         id: check-changed-files
         uses: tj-actions/verify-changed-files@v12.0
         with:
-          files : |
+          files: |
             *
+
       - name: Fail if code needs linting
         if: steps.check-changed-files.outputs.files_changed == 'true'
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,14 +15,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.49
-          only-new-issues: true
-      - name: install gci
-        run: |
-          go install github.com/daixiang0/gci@latest
       - name: make fix
         run: |
           make fix

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      - name: make fix
+
+      - name: make lint-fix
         run: |
-          make fix
+          make lint-fix
+
       - name: Check for changes
         id: check-changed-files
         uses: tj-actions/verify-changed-files@v12.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+# macOS metadata
 .DS_Store
 
-go.work.sum
+# Go workspace - checksums for necessary leftover modules
+/go.work.sum
+
+# Binaries
+/hack/bin/
+
+# Makefile things
+/tmp/
+
+# Output from 'go-junit-report'
+/report.xml

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -85,3 +85,32 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
+
+linters-settings:
+  gci:
+    # Section configuration to compare against.
+    # Section names are case-insensitive and may contain parameters in ().
+    # The default order of sections is `standard > default > custom > blank > dot`,
+    # If `custom-order` is `true`, it follows the order of `sections` option.
+    # Default: ["standard", "default"]
+    sections:
+      # Standard section: captures all standard packages.
+      - standard
+      # Default section: contains all imports that could not be matched to another section type.
+      - default
+      # Custom section: groups all imports with the specified Prefix.
+      - prefix(github.com/ovotech)
+      - prefix(github.com/ovotech/go-sync)
+      # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+      - blank
+      # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+      - dot
+
+    # Skip generated files.
+    # Default: true
+    skip-generated: true
+
+    # Enable custom order of sections.
+    # If `true`, make the section order the same as the order of `sections`.
+    # Default: false
+    custom-order: true

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,5 +1,3 @@
 # Default ignored files
 /shelf/
 /workspace.xml
-
-golinter.xml

--- a/.idea/go-sync.iml
+++ b/.idea/go-sync.iml
@@ -5,6 +5,8 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/hack/bin" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/golinter.xml
+++ b/.idea/golinter.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoLinterSettings">
+    <option name="enableCustomProjectDir" value="false" />
+    <option name="enabledLinters">
+      <list>
+        <option value="decorder" />
+        <option value="exportloopref" />
+        <option value="funlen" />
+        <option value="noctx" />
+        <option value="gocritic" />
+        <option value="gci" />
+        <option value="loggercheck" />
+        <option value="gocognit" />
+        <option value="maintidx" />
+        <option value="nestif" />
+        <option value="grouper" />
+        <option value="wsl" />
+        <option value="varnamelen" />
+        <option value="asasalint" />
+        <option value="exhaustive" />
+        <option value="bidichk" />
+        <option value="nilerr" />
+        <option value="revive" />
+        <option value="prealloc" />
+        <option value="staticcheck" />
+        <option value="errorlint" />
+        <option value="gomnd" />
+        <option value="misspell" />
+        <option value="errname" />
+        <option value="typecheck" />
+        <option value="gochecknoinits" />
+        <option value="nosprintfhostport" />
+        <option value="thelper" />
+        <option value="tparallel" />
+        <option value="asciicheck" />
+        <option value="testpackage" />
+        <option value="nolintlint" />
+        <option value="gosec" />
+        <option value="goerr113" />
+        <option value="gomodguard" />
+        <option value="godox" />
+        <option value="unconvert" />
+        <option value="unused" />
+        <option value="usestdlibvars" />
+        <option value="depguard" />
+        <option value="paralleltest" />
+        <option value="godot" />
+        <option value="goprintffuncname" />
+        <option value="gosimple" />
+        <option value="gocyclo" />
+        <option value="predeclared" />
+        <option value="importas" />
+        <option value="errchkjson" />
+        <option value="cyclop" />
+        <option value="goconst" />
+        <option value="reassign" />
+        <option value="errcheck" />
+        <option value="dogsled" />
+        <option value="nilnil" />
+        <option value="tenv" />
+        <option value="ineffassign" />
+        <option value="unparam" />
+        <option value="goheader" />
+        <option value="nakedret" />
+        <option value="promlinter" />
+        <option value="execinquery" />
+        <option value="nlreturn" />
+        <option value="durationcheck" />
+        <option value="gochecknoglobals" />
+        <option value="dupl" />
+        <option value="govet" />
+        <option value="forbidigo" />
+        <option value="nonamedreturns" />
+        <option value="gomoddirectives" />
+        <option value="tagliatelle" />
+        <option value="wrapcheck" />
+        <option value="lll" />
+        <option value="makezero" />
+        <option value="bodyclose" />
+        <option value="containedctx" />
+        <option value="gofmt" />
+        <option value="stylecheck" />
+        <option value="contextcheck" />
+        <option value="whitespace" />
+        <option value="interfacebloat" />
+        <option value="goimports" />
+      </list>
+    </option>
+    <option name="goLinterExe" value="$PROJECT_DIR$/hack/bin/golangci-lint" />
+    <option name="linterSelected" value="true" />
+  </component>
+</project>

--- a/.idea/runConfigurations/go_test.xml
+++ b/.idea/runConfigurations/go_test.xml
@@ -1,8 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="go test" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
-    <makefile filename="$PROJECT_DIR$/Makefile" target="test" workingDirectory="" arguments="">
-      <envs />
-    </makefile>
-    <method v="2" />
-  </configuration>
-</component>

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -2,31 +2,7 @@
 <project version="4">
   <component name="ProjectTasksOptions">
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="-w $FilePath$" />
-      <option name="checkSyntaxErrors" value="true" />
-      <option name="description" />
-      <option name="exitCodeBehavior" value="NEVER" />
-      <option name="fileExtension" value="go" />
-      <option name="immediateSync" value="false" />
-      <option name="name" value="gofmt" />
-      <option name="output" value="$FilePath$" />
-      <option name="outputFilters">
-        <array />
-      </option>
-      <option name="outputFromStdout" value="false" />
-      <option name="program" value="gofmt" />
-      <option name="runOnExternalChanges" value="true" />
-      <option name="scopeName" value="Project Files" />
-      <option name="trackOnlyRoot" value="true" />
-      <option name="workingDir" value="$ProjectFileDir$" />
-      <envs>
-        <env name="GOROOT" value="$GOROOT$" />
-        <env name="GOPATH" value="$GOPATH$" />
-        <env name="PATH" value="$GoBinDirs$" />
-      </envs>
-    </TaskOptions>
-    <TaskOptions isEnabled="true">
-      <option name="arguments" value="write $FilePath$" />
+      <option name="arguments" value="write $FilePath$ --skip-generated -s standard,default,prefix(github.com/ovotech),prefix(github.com/ovotech/go-sync),blank,dot" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />
       <option name="exitCodeBehavior" value="NEVER" />
@@ -38,7 +14,7 @@
         <array />
       </option>
       <option name="outputFromStdout" value="false" />
-      <option name="program" value="gci" />
+      <option name="program" value="$PROJECT_DIR$/hack/bin/gci" />
       <option name="runOnExternalChanges" value="true" />
       <option name="scopeName" value="Project Files" />
       <option name="trackOnlyRoot" value="true" />
@@ -50,7 +26,31 @@
       </envs>
     </TaskOptions>
     <TaskOptions isEnabled="true">
-      <option name="arguments" value="run $FileDir$" />
+      <option name="arguments" value="-w $FilePath$" />
+      <option name="checkSyntaxErrors" value="true" />
+      <option name="description" />
+      <option name="exitCodeBehavior" value="NEVER" />
+      <option name="fileExtension" value="go" />
+      <option name="immediateSync" value="false" />
+      <option name="name" value="gofumpt" />
+      <option name="output" value="$FilePath$" />
+      <option name="outputFilters">
+        <array />
+      </option>
+      <option name="outputFromStdout" value="false" />
+      <option name="program" value="$PROJECT_DIR$/hack/bin/gofumpt" />
+      <option name="runOnExternalChanges" value="true" />
+      <option name="scopeName" value="Project Files" />
+      <option name="trackOnlyRoot" value="true" />
+      <option name="workingDir" value="$ProjectFileDir$" />
+      <envs>
+        <env name="GOROOT" value="$GOROOT$" />
+        <env name="GOPATH" value="$GOPATH$" />
+        <env name="PATH" value="$GoBinDirs$" />
+      </envs>
+    </TaskOptions>
+    <TaskOptions isEnabled="true">
+      <option name="arguments" value="run --fix $FileDir$" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />
       <option name="exitCodeBehavior" value="NEVER" />
@@ -62,7 +62,7 @@
         <array />
       </option>
       <option name="outputFromStdout" value="false" />
-      <option name="program" value="golangci-lint" />
+      <option name="program" value="$PROJECT_DIR$/hack/bin/golangci-lint" />
       <option name="runOnExternalChanges" value="true" />
       <option name="scopeName" value="Project Files" />
       <option name="trackOnlyRoot" value="true" />

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,9 @@
+{
+  "MD013": {
+    "line_length": 120
+  },
+  "MD033": {
+    "allowed_elements": ["div", "details", "summary"]
+  },
+  "MD041": false
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
+  "MD010": { "ignore_code_languages": ["go"] },
   "MD013": {
     "line_length": 120
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,23 +15,21 @@ We also run the following tooling to ensure code quality:
 
 1. [golangci-lint](https://golangci-lint.run/) for code quality.
 2. [mockery](https://github.com/vektra/mockery) generates mocks for easy testing.
-   ```sh
-   go install github.com/vektra/mockery/v2@latest
-   ```
 3. [gci](https://github.com/daixiang0/gci) for consistent, deterministic imports.
-   ```shell
-   go install github.com/daixiang0/gci@latest
-   ```
 
 We run linters to ensure that code being checked in matches our quality standards, and have included a Makefile in this
-repo containing common commands to assist with this. 
+repo containing common commands to assist with this.
+All tools necessary to action the various Makefile targets will be automatically installed on-demand under the
+`hack/bin/` sub-directory within this project.
 
-| Command              | Description                         |
-|----------------------|-------------------------------------|
-| `make` / `make help` | Display list of available commands. |
-| `make lint`          | Lint Go Sync.                       |
-| `make fix`           | Fix some common linter errors.      |
-| `make generate`      | Generate automated code.            |
+| Command         | Description                    |
+| --------------- | ------------------------------ |
+| `make generate` | Generate automated code.       |
+| `make lint`     | Lint Go Sync.                  |
+| `make lint-fix` | Fix some common linter errors. |
+
+The above is a small subset of available Makefile targets.
+Running `make` or `make help` will display a more complete list of available targets.
 
 ## Developing an adapter 🔌
 An adapter's basic functionality is to provide a common interface to a third party service. In order to keep 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,10 +51,10 @@ We've built a command-line tool to automatically scaffold a new adapter: <https:
 package myadapter
 
 import (
- "context"
- "errors"
- "fmt"
- "github.com/ovotech/go-sync/pkg/ports"
+	"context"
+	"errors"
+	"fmt"
+	"github.com/ovotech/go-sync/pkg/ports"
 )
 
 // Ensure the adapter type fully satisfies the ports.Adapter interface.
@@ -65,19 +65,19 @@ var ErrNotImplemented = errors.New("not implemented")
 type MyAdapter struct{}
 
 func New() *MyAdapter {
- return &MyAdapter {}
+	return &MyAdapter {}
 }
 
 func (m *MyAdapter) Get(_ context.Context) ([]string, error) {
- return nil, fmt.Errorf("myadapter.get -> %w", ErrNotImplemented)
+	return nil, fmt.Errorf("myadapter.get -> %w", ErrNotImplemented)
 }
 
 func (m *MyAdapter) Add(_ context.Context, _ []string) error {
- return fmt.Errorf("myadapter.add -> %w", ErrNotImplemented)
+	return fmt.Errorf("myadapter.add -> %w", ErrNotImplemented)
 }
 
 func (m *MyAdapter) Remove(_ context.Context, _ []string) error {
- return fmt.Errorf("myadapter.remove -> %w", ErrNotImplemented)
+	return fmt.Errorf("myadapter.remove -> %w", ErrNotImplemented)
 }
 ```
 
@@ -95,7 +95,7 @@ Go Sync's error handling convention is to wrap all errors:
 
 ```go
 if err != nil {
-    return fmt.Errorf("some.context.here -> %w", err)
+	return fmt.Errorf("some.context.here -> %w", err)
 }
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,8 @@
 First of all, thank you for wanting to contribute to Go Sync ✨
 
 ## Preparation 🍳
-We recommend asdf, it's our recommended way of managing our runtime CLIs:
+
+We recommend `asdf`, it's our recommended way of managing our runtime CLIs:
 
 1. [asdf](https://asdf-vm.com/)
 2. [asdf-golang](https://github.com/kennyp/asdf-golang) (install via `asdf plugin-add golang`)
@@ -32,15 +33,16 @@ The above is a small subset of available Makefile targets.
 Running `make` or `make help` will display a more complete list of available targets.
 
 ## Developing an adapter 🔌
-An adapter's basic functionality is to provide a common interface to a third party service. In order to keep 
-synchronisation simple, Sync only works with strings. For users, we recommend email addresses as these are usually 
+
+An adapter's basic functionality is to provide a common interface to a third party service. In order to keep
+synchronisation simple, Sync only works with strings. For users, we recommend email addresses as these are usually
 common between services.
 
 [Adapter interface documentation](https://pkg.go.dev/github.com/ovotech/go-sync/pkg/ports#Adapter)
 
 Following our specification, your adapter will be compatible with Sync.
 
-We've built a command-line tool to automatically scaffold a new adapter: https://github.com/ovotech/go-sync-adapter-gen
+We've built a command-line tool to automatically scaffold a new adapter: <https://github.com/ovotech/go-sync-adapter-gen>
 
 <details>
 <summary>Example adapter</summary>
@@ -49,10 +51,10 @@ We've built a command-line tool to automatically scaffold a new adapter: https:/
 package myadapter
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"github.com/ovotech/go-sync/pkg/ports"
+ "context"
+ "errors"
+ "fmt"
+ "github.com/ovotech/go-sync/pkg/ports"
 )
 
 // Ensure the adapter type fully satisfies the ports.Adapter interface.
@@ -63,33 +65,37 @@ var ErrNotImplemented = errors.New("not implemented")
 type MyAdapter struct{}
 
 func New() *MyAdapter {
-	return &MyAdapter {}
+ return &MyAdapter {}
 }
 
 func (m *MyAdapter) Get(_ context.Context) ([]string, error) {
-	return nil, fmt.Errorf("myadapter.get -> %w", ErrNotImplemented)
+ return nil, fmt.Errorf("myadapter.get -> %w", ErrNotImplemented)
 }
 
 func (m *MyAdapter) Add(_ context.Context, _ []string) error {
-	return fmt.Errorf("myadapter.add -> %w", ErrNotImplemented)
+ return fmt.Errorf("myadapter.add -> %w", ErrNotImplemented)
 }
 
 func (m *MyAdapter) Remove(_ context.Context, _ []string) error {
-	return fmt.Errorf("myadapter.remove -> %w", ErrNotImplemented)
+ return fmt.Errorf("myadapter.remove -> %w", ErrNotImplemented)
 }
 ```
+
 </details>
 
 ### Add/Remove
+
 The slice of strings passed to the Add/Remove methods are the diff between the source and destination adapters. If your
 service needs a list of users, cache the response from Get in your adapter, and combine the results in your Add/Remove
 methods.
 
 ### Error handling
+
 Go Sync's error handling convention is to wrap all errors:
+
 ```go
 if err != nil {
-    return fmt.Errorf("some.context.here -> %w", err)	
+    return fmt.Errorf("some.context.here -> %w", err)
 }
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,7 @@ hack/bin/mockery:
 
 hack/bin/yq:
 > mkdir -p $(@D)
-> os="$(shell uname -s | tr '[:upper:]' '[:lower:]')"
-> arch="$(shell uname -m)"
-> curl --fail --location --output $@ --remove-on-error --show-error --silent \
-  "https://github.com/mikefarah/yq/releases/latest/download/yq_$${os}_$${arch}"
-> chmod +x $@
+> GOBIN=$(CURDIR)/hack/bin go install github.com/mikefarah/yq/v4@latest
 
 # Tests look for sentinel files to determine whether or not they need to be run again.
 # If any Go code file has been changed since the sentinel file was last touched, it will trigger a retest.

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ MAKEFLAGS += --jobs
 ADAPTERS := $(shell find adapters -depth 1 -type d | awk '{ print "./"$$1"/..." }')
 
 # Configure an 'all' target to cover the bases.
-all: test lint build ## Test and lint and build.
+all: generate test lint build ## Generate and test and lint and build.
 .PHONY: all
 
 help: Makefile ## Display list of available commands.
@@ -97,19 +97,19 @@ hack/bin/yq:
 
 # Tests look for sentinel files to determine whether or not they need to be run again.
 # If any Go code file has been changed since the sentinel file was last touched, it will trigger a retest.
-test: tmp/.tests-passed.sentinel ## Run tests.
-test-cover: tmp/.cover-tests-passed.sentinel ## Run all tests with the race detector and output a coverage profile.
+test: tmp/.tests-passed.sentinel ## Run tests. Will also generate.
+test-cover: tmp/.cover-tests-passed.sentinel ## Run all tests with the race detector, and output a coverage profile.
 bench: tmp/.benchmarks-ran.sentinel ## Run enough iterations of each benchmark to take ten seconds each.
 report: tmp/.report-ran.sentinel ## Test and produce a JUnit report.
 .PHONY: test test-cover bench report
 
 # Linter checks look for sentinel files to determine whether or not they need to check again.
 # If any Go code file has been changed since the sentinel file was last touched, it will trigger a rerun.
-lint: tmp/.linted.sentinel ## Lint all of the Go code. Will also test.
+lint: tmp/.linted.sentinel ## Lint all of the Go code. Will also generate and test.
 .PHONY: lint
 
 # If any Go code file has been changed since the binary was last built, it will trigger a rebuild.
-build: tmp/.built.sentinel ## Build the library. Will also test and lint.
+build: tmp/.built.sentinel ## Build the library. Will also generate, test, and lint.
 .PHONY: build
 
 clean: ## Clean up Go's output (if any), test coverage data, Go workspace checksums, and output and temp sub-directories.
@@ -125,7 +125,7 @@ clean-all: clean clean-hack ## Clean all of the things.
 .PHONY: clean-all
 
 # Tests - re-run if any Go files have changes since 'tmp/.tests-passed.sentinel' was last touched.
-tmp/.tests-passed.sentinel: $(GO_FILES)
+tmp/.tests-passed.sentinel: generate $(GO_FILES)
 > mkdir -p $(@D)
 > go test -count=1 -v ./... $(ADAPTERS)
 > touch $@

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ADAPTERS := $(shell find adapters -depth 1 -type d | awk '{ print "./"$$1"/..." 
 all: generate test lint build ## Generate and test and lint and build.
 .PHONY: all
 
-help: Makefile ## Display list of available commands.
+help: Makefile ## Display this list of available Make targets.
 > @grep -E '(^[a-zA-Z/_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | sort | awk 'BEGIN { FS = ":.*?## " }; { printf "\033[32m%-30s\033[0m %s\n", $$1, $$2 }' | sed -e 's/\[32m##/[33m/'
 .PHONY: help
 
@@ -100,7 +100,7 @@ hack/bin/yq:
 test: tmp/.tests-passed.sentinel ## Run tests. Will also generate.
 test-cover: tmp/.cover-tests-passed.sentinel ## Run all tests with the race detector, and output a coverage profile.
 bench: tmp/.benchmarks-ran.sentinel ## Run enough iterations of each benchmark to take ten seconds each.
-report: tmp/.report-ran.sentinel ## Test and produce a JUnit report.
+report: tmp/.report-ran.sentinel ## Run tests, and produce a JUnit report.
 .PHONY: test test-cover bench report
 
 # Linter checks look for sentinel files to determine whether or not they need to check again.

--- a/README.md
+++ b/README.md
@@ -51,18 +51,18 @@ source := myAdapter.New(client, "some-value")
 
 // Initialise an adapter using an Init function.
 destination, err := myAdapter.Init(map[gosync.ConfigKey]string{
- myAdapter.Token:     "some-token",
- myAdapter.Something: "some-value",
+	myAdapter.Token:     "some-token",
+	myAdapter.Something: "some-value",
 })
 if err != nil {
-    log.Fatal(err)
+	log.Fatal(err)
 }
 
 sync := gosync.New(source)
 
 err := sync.SyncWith(context.Background(), destination)
 if err != nil {
-    log.Fatal(err)
+	log.Fatal(err)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 | **⚠️ Go Sync is under active development and subject to breaking changes.** |
-|-----------------------------------------------------------------------------|
+| -------------------------------------------------------------------------- |
 
 # Go Sync (all the things)
 
@@ -31,14 +31,16 @@ go get github.com/ovotech/go-sync@latest
 go get github.com/ovotech/go-sync/adapters/slack@latest
 ```
 
-You're ready to Go Sync 🎉
+You're ready to Go Sync! 🎉
 
 ## Usage
-[Read the documentation on pkg.go.dev](https://pkg.go.dev/github.com/ovotech/go-sync)
+
+Read the [documentation on `pkg.go.dev`](https://pkg.go.dev/github.com/ovotech/go-sync).
 
 Go Sync consists of two fundamental parts:
+
 1. [Sync](#sync-)
-2. [Adapters ](#adaptersadapters-)
+2. [Adapters](#adapters-)
 
 As long as your adapters are compatible, you can synchronise anything.
 
@@ -49,8 +51,8 @@ source := myAdapter.New(client, "some-value")
 
 // Initialise an adapter using an Init function.
 destination, err := myAdapter.Init(map[gosync.ConfigKey]string{
-	myAdapter.Token:     "some-token", 
-	myAdapter.Something: "some-value",
+ myAdapter.Token:     "some-token",
+ myAdapter.Something: "some-value",
 })
 if err != nil {
     log.Fatal(err)
@@ -65,11 +67,13 @@ if err != nil {
 ```
 
 ### Init
-While we recommend using `New` to create an adapter in most cases, some plugins may provide an`Init` function for
+
+While we recommend using `New` to create an adapter in most cases, some plugins may provide an `Init` function for
 instantiating them too. Init functions are intended for programmatically creating adapters either via environment
 variables or some other dynamic configuration.
 
 ## Sync 🔄
+
 Sync is the logic that powers the automation. It accepts a source adapter, and synchronises it with destination
 adapters.
 
@@ -83,8 +87,10 @@ Sync is only uni-directional by design. You know where your things are, and wher
 5. Repeat from 2 for further adapters.
 
 ## [Adapters](./adapters) 🔌
-Adapters provide a common interface to services. Adapters must implement our [Adapter interface](https://pkg.go.dev/github.com/ovotech/go-sync#Adapter)
-and functionally perform 3 things:
+
+Adapters provide a common interface to services.
+Adapters must implement our [Adapter interface](https://pkg.go.dev/github.com/ovotech/go-sync#Adapter) and functionally
+perform 3 things:
 
 1. Get the things.
 2. Add some things.

--- a/adapters/github/discovery/mock_GitHubDiscovery_test.go
+++ b/adapters/github/discovery/mock_GitHubDiscovery_test.go
@@ -50,8 +50,8 @@ type MockGitHubDiscovery_GetEmailFromUsername_Call struct {
 }
 
 // GetEmailFromUsername is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 []string
+//   - _a0 context.Context
+//   - _a1 []string
 func (_e *MockGitHubDiscovery_Expecter) GetEmailFromUsername(_a0 interface{}, _a1 interface{}) *MockGitHubDiscovery_GetEmailFromUsername_Call {
 	return &MockGitHubDiscovery_GetEmailFromUsername_Call{Call: _e.mock.On("GetEmailFromUsername", _a0, _a1)}
 }
@@ -97,8 +97,8 @@ type MockGitHubDiscovery_GetUsernameFromEmail_Call struct {
 }
 
 // GetUsernameFromEmail is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 []string
+//   - _a0 context.Context
+//   - _a1 []string
 func (_e *MockGitHubDiscovery_Expecter) GetUsernameFromEmail(_a0 interface{}, _a1 interface{}) *MockGitHubDiscovery_GetUsernameFromEmail_Call {
 	return &MockGitHubDiscovery_GetUsernameFromEmail_Call{Call: _e.mock.On("GetUsernameFromEmail", _a0, _a1)}
 }

--- a/adapters/github/discovery/saml/mock_iGitHubV4Saml_test.go
+++ b/adapters/github/discovery/saml/mock_iGitHubV4Saml_test.go
@@ -41,9 +41,9 @@ type mockIGitHubV4Saml_Query_Call struct {
 }
 
 // Query is a helper method to define mock.On call
-//  - ctx context.Context
-//  - q interface{}
-//  - variables map[string]interface{}
+//   - ctx context.Context
+//   - q interface{}
+//   - variables map[string]interface{}
 func (_e *mockIGitHubV4Saml_Expecter) Query(ctx interface{}, q interface{}, variables interface{}) *mockIGitHubV4Saml_Query_Call {
 	return &mockIGitHubV4Saml_Query_Call{Call: _e.mock.On("Query", ctx, q, variables)}
 }

--- a/adapters/github/discovery/saml/saml.go
+++ b/adapters/github/discovery/saml/saml.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ovotech/go-sync/adapters/github/discovery"
 	"github.com/shurcooL/githubv4"
+
+	"github.com/ovotech/go-sync/adapters/github/discovery"
 )
 
 // Ensure the Saml adapter type fully satisfies the discovery.GitHubDiscovery interface.

--- a/adapters/github/discovery/saml/saml_internal_test.go
+++ b/adapters/github/discovery/saml/saml_internal_test.go
@@ -63,11 +63,13 @@ func TestSaml_GetEmailFromUsername(t *testing.T) { //nolint:dupl
 	}
 
 	gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
-		"login": githubv4.String("foo"), "org": githubv4.String("test")},
+		"login": githubv4.String("foo"), "org": githubv4.String("test"),
+	},
 	).Run(queryFn("foo@email")).
 		Return(nil)
 	gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
-		"login": githubv4.String("bar"), "org": githubv4.String("test")},
+		"login": githubv4.String("bar"), "org": githubv4.String("test"),
+	},
 	).Run(queryFn("bar@email")).
 		Return(nil)
 
@@ -118,10 +120,12 @@ func TestSaml_GetUsernameFromEmail(t *testing.T) { //nolint:dupl
 	}
 
 	gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
-		"email": githubv4.String("foo@email"), "org": githubv4.String("test")},
+		"email": githubv4.String("foo@email"), "org": githubv4.String("test"),
+	},
 	).Run(queryFn("foo")).Return(nil)
 	gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
-		"email": githubv4.String("bar@email"), "org": githubv4.String("test")},
+		"email": githubv4.String("bar@email"), "org": githubv4.String("test"),
+	},
 	).Run(queryFn("bar")).
 		Return(nil)
 

--- a/adapters/github/team/mock_iGitHubTeam_test.go
+++ b/adapters/github/team/mock_iGitHubTeam_test.go
@@ -60,11 +60,11 @@ type mockIGitHubTeam_AddTeamMembershipBySlug_Call struct {
 }
 
 // AddTeamMembershipBySlug is a helper method to define mock.On call
-//  - ctx context.Context
-//  - org string
-//  - slug string
-//  - user string
-//  - opts *github.TeamAddTeamMembershipOptions
+//   - ctx context.Context
+//   - org string
+//   - slug string
+//   - user string
+//   - opts *github.TeamAddTeamMembershipOptions
 func (_e *mockIGitHubTeam_Expecter) AddTeamMembershipBySlug(ctx interface{}, org interface{}, slug interface{}, user interface{}, opts interface{}) *mockIGitHubTeam_AddTeamMembershipBySlug_Call {
 	return &mockIGitHubTeam_AddTeamMembershipBySlug_Call{Call: _e.mock.On("AddTeamMembershipBySlug", ctx, org, slug, user, opts)}
 }
@@ -119,10 +119,10 @@ type mockIGitHubTeam_ListTeamMembersBySlug_Call struct {
 }
 
 // ListTeamMembersBySlug is a helper method to define mock.On call
-//  - ctx context.Context
-//  - org string
-//  - slug string
-//  - opts *github.TeamListTeamMembersOptions
+//   - ctx context.Context
+//   - org string
+//   - slug string
+//   - opts *github.TeamListTeamMembersOptions
 func (_e *mockIGitHubTeam_Expecter) ListTeamMembersBySlug(ctx interface{}, org interface{}, slug interface{}, opts interface{}) *mockIGitHubTeam_ListTeamMembersBySlug_Call {
 	return &mockIGitHubTeam_ListTeamMembersBySlug_Call{Call: _e.mock.On("ListTeamMembersBySlug", ctx, org, slug, opts)}
 }
@@ -168,10 +168,10 @@ type mockIGitHubTeam_RemoveTeamMembershipBySlug_Call struct {
 }
 
 // RemoveTeamMembershipBySlug is a helper method to define mock.On call
-//  - ctx context.Context
-//  - org string
-//  - slug string
-//  - user string
+//   - ctx context.Context
+//   - org string
+//   - slug string
+//   - user string
 func (_e *mockIGitHubTeam_Expecter) RemoveTeamMembershipBySlug(ctx interface{}, org interface{}, slug interface{}, user interface{}) *mockIGitHubTeam_RemoveTeamMembershipBySlug_Call {
 	return &mockIGitHubTeam_RemoveTeamMembershipBySlug_Call{Call: _e.mock.On("RemoveTeamMembershipBySlug", ctx, org, slug, user)}
 }

--- a/adapters/github/team/team.go
+++ b/adapters/github/team/team.go
@@ -159,7 +159,7 @@ func (t *Team) Add(ctx context.Context, emails []string) error {
 	}
 
 	for _, name := range names {
-		var opts = &github.TeamAddTeamMembershipOptions{
+		opts := &github.TeamAddTeamMembershipOptions{
 			Role: "member",
 		}
 

--- a/adapters/github/team/team.go
+++ b/adapters/github/team/team.go
@@ -29,11 +29,12 @@ import (
 	"os"
 
 	"github.com/google/go-github/v47/github"
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
+
 	gosync "github.com/ovotech/go-sync"
 	"github.com/ovotech/go-sync/adapters/github/discovery"
 	"github.com/ovotech/go-sync/adapters/github/discovery/saml"
-	"github.com/shurcooL/githubv4"
-	"golang.org/x/oauth2"
 )
 
 /*

--- a/adapters/github/team/team_internal_test.go
+++ b/adapters/github/team/team_internal_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v47/github"
-	gosync "github.com/ovotech/go-sync"
-	"github.com/ovotech/go-sync/adapters/github/discovery/saml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	gosync "github.com/ovotech/go-sync"
+	"github.com/ovotech/go-sync/adapters/github/discovery/saml"
 )
 
 func TestNew(t *testing.T) {

--- a/adapters/github/team/team_test.go
+++ b/adapters/github/team/team_test.go
@@ -5,11 +5,12 @@ import (
 	"log"
 
 	"github.com/google/go-github/v47/github"
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
+
 	gosync "github.com/ovotech/go-sync"
 	"github.com/ovotech/go-sync/adapters/github/discovery/saml"
 	"github.com/ovotech/go-sync/adapters/github/team"
-	"github.com/shurcooL/githubv4"
-	"golang.org/x/oauth2"
 )
 
 func ExampleNew() {

--- a/adapters/google/group/group.go
+++ b/adapters/google/group/group.go
@@ -19,9 +19,10 @@ import (
 	"log"
 	"os"
 
-	gosync "github.com/ovotech/go-sync"
 	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/option"
+
+	gosync "github.com/ovotech/go-sync"
 )
 
 /*

--- a/adapters/google/group/group_internal_test.go
+++ b/adapters/google/group/group_internal_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	gosync "github.com/ovotech/go-sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	admin "google.golang.org/api/admin/directory/v1"
+
+	gosync "github.com/ovotech/go-sync"
 )
 
 type mockCalls struct {

--- a/adapters/google/group/group_test.go
+++ b/adapters/google/group/group_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"log"
 
+	admin "google.golang.org/api/admin/directory/v1"
+
 	gosync "github.com/ovotech/go-sync"
 	"github.com/ovotech/go-sync/adapters/google/group"
-	admin "google.golang.org/api/admin/directory/v1"
 )
 
 func ExampleNew() {

--- a/adapters/google/group/mock_iMembersService_test.go
+++ b/adapters/google/group/mock_iMembersService_test.go
@@ -42,8 +42,8 @@ type mockIMembersService_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//  - groupKey string
-//  - memberKey string
+//   - groupKey string
+//   - memberKey string
 func (_e *mockIMembersService_Expecter) Delete(groupKey interface{}, memberKey interface{}) *mockIMembersService_Delete_Call {
 	return &mockIMembersService_Delete_Call{Call: _e.mock.On("Delete", groupKey, memberKey)}
 }
@@ -82,8 +82,8 @@ type mockIMembersService_Insert_Call struct {
 }
 
 // Insert is a helper method to define mock.On call
-//  - groupKey string
-//  - member *admin.Member
+//   - groupKey string
+//   - member *admin.Member
 func (_e *mockIMembersService_Expecter) Insert(groupKey interface{}, member interface{}) *mockIMembersService_Insert_Call {
 	return &mockIMembersService_Insert_Call{Call: _e.mock.On("Insert", groupKey, member)}
 }
@@ -122,7 +122,7 @@ type mockIMembersService_List_Call struct {
 }
 
 // List is a helper method to define mock.On call
-//  - groupKey string
+//   - groupKey string
 func (_e *mockIMembersService_Expecter) List(groupKey interface{}) *mockIMembersService_List_Call {
 	return &mockIMembersService_List_Call{Call: _e.mock.On("List", groupKey)}
 }

--- a/adapters/opsgenie/oncall/mock_iOpsgenieSchedule_test.go
+++ b/adapters/opsgenie/oncall/mock_iOpsgenieSchedule_test.go
@@ -51,8 +51,8 @@ type mockIOpsgenieSchedule_GetOnCalls_Call struct {
 }
 
 // GetOnCalls is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - request *schedule.GetOnCallsRequest
+//   - _a0 context.Context
+//   - request *schedule.GetOnCallsRequest
 func (_e *mockIOpsgenieSchedule_Expecter) GetOnCalls(_a0 interface{}, request interface{}) *mockIOpsgenieSchedule_GetOnCalls_Call {
 	return &mockIOpsgenieSchedule_GetOnCalls_Call{Call: _e.mock.On("GetOnCalls", _a0, request)}
 }

--- a/adapters/opsgenie/oncall/oncall.go
+++ b/adapters/opsgenie/oncall/oncall.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/schedule"
+
 	gosync "github.com/ovotech/go-sync"
 )
 

--- a/adapters/opsgenie/oncall/oncall.go
+++ b/adapters/opsgenie/oncall/oncall.go
@@ -89,7 +89,6 @@ func (o *OnCall) Remove(_ context.Context, _ []string) error {
 // New Opsgenie OnCall [gosync.Adapter].
 func New(opsgenieConfig *client.Config, scheduleID string, optsFn ...func(schedule *OnCall)) (*OnCall, error) {
 	scheduleClient, err := schedule.NewClient(opsgenieConfig)
-
 	if err != nil {
 		return nil, fmt.Errorf("opsgenie.oncall.new -> %w", err)
 	}

--- a/adapters/opsgenie/oncall/oncall_internal_test.go
+++ b/adapters/opsgenie/oncall/oncall_internal_test.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/schedule"
-	gosync "github.com/ovotech/go-sync"
 	"github.com/stretchr/testify/assert"
+
+	gosync "github.com/ovotech/go-sync"
 )
 
 var errGetOnCall = errors.New("an example error")

--- a/adapters/opsgenie/oncall/oncall_test.go
+++ b/adapters/opsgenie/oncall/oncall_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+
 	gosync "github.com/ovotech/go-sync"
 	"github.com/ovotech/go-sync/adapters/opsgenie/oncall"
 )

--- a/adapters/opsgenie/schedule/mock_iOpsgenieSchedule_test.go
+++ b/adapters/opsgenie/schedule/mock_iOpsgenieSchedule_test.go
@@ -51,8 +51,8 @@ type mockIOpsgenieSchedule_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//  - ctx context.Context
-//  - request *opsgenie_go_sdk_v2schedule.GetRequest
+//   - ctx context.Context
+//   - request *opsgenie_go_sdk_v2schedule.GetRequest
 func (_e *mockIOpsgenieSchedule_Expecter) Get(ctx interface{}, request interface{}) *mockIOpsgenieSchedule_Get_Call {
 	return &mockIOpsgenieSchedule_Get_Call{Call: _e.mock.On("Get", ctx, request)}
 }
@@ -98,8 +98,8 @@ type mockIOpsgenieSchedule_UpdateRotation_Call struct {
 }
 
 // UpdateRotation is a helper method to define mock.On call
-//  - ctx context.Context
-//  - request *opsgenie_go_sdk_v2schedule.UpdateRotationRequest
+//   - ctx context.Context
+//   - request *opsgenie_go_sdk_v2schedule.UpdateRotationRequest
 func (_e *mockIOpsgenieSchedule_Expecter) UpdateRotation(ctx interface{}, request interface{}) *mockIOpsgenieSchedule_UpdateRotation_Call {
 	return &mockIOpsgenieSchedule_UpdateRotation_Call{Call: _e.mock.On("UpdateRotation", ctx, request)}
 }

--- a/adapters/opsgenie/schedule/schedule.go
+++ b/adapters/opsgenie/schedule/schedule.go
@@ -29,8 +29,9 @@ import (
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 	ogSchedule "github.com/opsgenie/opsgenie-go-sdk-v2/schedule"
-	gosync "github.com/ovotech/go-sync"
 	"golang.org/x/exp/slices"
+
+	gosync "github.com/ovotech/go-sync"
 )
 
 /*

--- a/adapters/opsgenie/schedule/schedule_internal_test.go
+++ b/adapters/opsgenie/schedule/schedule_internal_test.go
@@ -63,7 +63,7 @@ func testBuildScheduleGetResult(numRotations int, emails ...string) *schedule.Ge
 	rotations := make([]og.Rotation, numRotations)
 
 	for index, rotationEmails := range chunkedEmails {
-		participants := make([]og.Participant, len(rotationEmails))
+		participants := make([]og.Participant, 0, len(rotationEmails))
 		for _, email := range rotationEmails {
 			participants = append(participants, og.Participant{
 				Type:     og.User,

--- a/adapters/opsgenie/schedule/schedule_internal_test.go
+++ b/adapters/opsgenie/schedule/schedule_internal_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/schedule"
-	gosync "github.com/ovotech/go-sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	gosync "github.com/ovotech/go-sync"
 )
 
 var errResponse = errors.New("an example error")

--- a/adapters/opsgenie/schedule/schedule_internal_test.go
+++ b/adapters/opsgenie/schedule/schedule_internal_test.go
@@ -62,7 +62,7 @@ func testBuildScheduleGetResult(numRotations int, emails ...string) *schedule.Ge
 	rotations := make([]og.Rotation, numRotations)
 
 	for index, rotationEmails := range chunkedEmails {
-		var participants = make([]og.Participant, len(rotationEmails))
+		participants := make([]og.Participant, len(rotationEmails))
 		for _, email := range rotationEmails {
 			participants = append(participants, og.Participant{
 				Type:     og.User,

--- a/adapters/opsgenie/schedule/schedule_test.go
+++ b/adapters/opsgenie/schedule/schedule_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+
 	gosync "github.com/ovotech/go-sync"
 	"github.com/ovotech/go-sync/adapters/opsgenie/schedule"
 )

--- a/adapters/slack/conversation/conversation.go
+++ b/adapters/slack/conversation/conversation.go
@@ -38,8 +38,9 @@ import (
 	"strings"
 	"time"
 
-	gosync "github.com/ovotech/go-sync"
 	"github.com/slack-go/slack"
+
+	gosync "github.com/ovotech/go-sync"
 )
 
 /*

--- a/adapters/slack/conversation/conversation_internal_test.go
+++ b/adapters/slack/conversation/conversation_internal_test.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"testing"
 
-	gosync "github.com/ovotech/go-sync"
 	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
+
+	gosync "github.com/ovotech/go-sync"
 )
 
 func TestNew(t *testing.T) {

--- a/adapters/slack/conversation/conversation_test.go
+++ b/adapters/slack/conversation/conversation_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"log"
 
+	"github.com/slack-go/slack"
+
 	gosync "github.com/ovotech/go-sync"
 	"github.com/ovotech/go-sync/adapters/slack/conversation"
-	"github.com/slack-go/slack"
 )
 
 func ExampleNew() {

--- a/adapters/slack/conversation/mock_iSlackConversation_test.go
+++ b/adapters/slack/conversation/mock_iSlackConversation_test.go
@@ -49,7 +49,7 @@ type mockISlackConversation_GetUserByEmail_Call struct {
 }
 
 // GetUserByEmail is a helper method to define mock.On call
-//  - email string
+//   - email string
 func (_e *mockISlackConversation_Expecter) GetUserByEmail(email interface{}) *mockISlackConversation_GetUserByEmail_Call {
 	return &mockISlackConversation_GetUserByEmail_Call{Call: _e.mock.On("GetUserByEmail", email)}
 }
@@ -102,7 +102,7 @@ type mockISlackConversation_GetUsersInConversation_Call struct {
 }
 
 // GetUsersInConversation is a helper method to define mock.On call
-//  - params *slack.GetUsersInConversationParameters
+//   - params *slack.GetUsersInConversationParameters
 func (_e *mockISlackConversation_Expecter) GetUsersInConversation(params interface{}) *mockISlackConversation_GetUsersInConversation_Call {
 	return &mockISlackConversation_GetUsersInConversation_Call{Call: _e.mock.On("GetUsersInConversation", params)}
 }
@@ -154,7 +154,7 @@ type mockISlackConversation_GetUsersInfo_Call struct {
 }
 
 // GetUsersInfo is a helper method to define mock.On call
-//  - users ...string
+//   - users ...string
 func (_e *mockISlackConversation_Expecter) GetUsersInfo(users ...interface{}) *mockISlackConversation_GetUsersInfo_Call {
 	return &mockISlackConversation_GetUsersInfo_Call{Call: _e.mock.On("GetUsersInfo",
 		append([]interface{}{}, users...)...)}
@@ -214,8 +214,8 @@ type mockISlackConversation_InviteUsersToConversation_Call struct {
 }
 
 // InviteUsersToConversation is a helper method to define mock.On call
-//  - channelID string
-//  - users ...string
+//   - channelID string
+//   - users ...string
 func (_e *mockISlackConversation_Expecter) InviteUsersToConversation(channelID interface{}, users ...interface{}) *mockISlackConversation_InviteUsersToConversation_Call {
 	return &mockISlackConversation_InviteUsersToConversation_Call{Call: _e.mock.On("InviteUsersToConversation",
 		append([]interface{}{channelID}, users...)...)}
@@ -259,8 +259,8 @@ type mockISlackConversation_KickUserFromConversation_Call struct {
 }
 
 // KickUserFromConversation is a helper method to define mock.On call
-//  - channelID string
-//  - user string
+//   - channelID string
+//   - user string
 func (_e *mockISlackConversation_Expecter) KickUserFromConversation(channelID interface{}, user interface{}) *mockISlackConversation_KickUserFromConversation_Call {
 	return &mockISlackConversation_KickUserFromConversation_Call{Call: _e.mock.On("KickUserFromConversation", channelID, user)}
 }

--- a/adapters/slack/usergroup/mock_iSlackUserGroup_test.go
+++ b/adapters/slack/usergroup/mock_iSlackUserGroup_test.go
@@ -51,8 +51,8 @@ type mockISlackUserGroup_GetUserByEmailContext_Call struct {
 }
 
 // GetUserByEmailContext is a helper method to define mock.On call
-//  - ctx context.Context
-//  - email string
+//   - ctx context.Context
+//   - email string
 func (_e *mockISlackUserGroup_Expecter) GetUserByEmailContext(ctx interface{}, email interface{}) *mockISlackUserGroup_GetUserByEmailContext_Call {
 	return &mockISlackUserGroup_GetUserByEmailContext_Call{Call: _e.mock.On("GetUserByEmailContext", ctx, email)}
 }
@@ -98,8 +98,8 @@ type mockISlackUserGroup_GetUserGroupMembersContext_Call struct {
 }
 
 // GetUserGroupMembersContext is a helper method to define mock.On call
-//  - ctx context.Context
-//  - userGroup string
+//   - ctx context.Context
+//   - userGroup string
 func (_e *mockISlackUserGroup_Expecter) GetUserGroupMembersContext(ctx interface{}, userGroup interface{}) *mockISlackUserGroup_GetUserGroupMembersContext_Call {
 	return &mockISlackUserGroup_GetUserGroupMembersContext_Call{Call: _e.mock.On("GetUserGroupMembersContext", ctx, userGroup)}
 }
@@ -152,8 +152,8 @@ type mockISlackUserGroup_GetUsersInfoContext_Call struct {
 }
 
 // GetUsersInfoContext is a helper method to define mock.On call
-//  - ctx context.Context
-//  - users ...string
+//   - ctx context.Context
+//   - users ...string
 func (_e *mockISlackUserGroup_Expecter) GetUsersInfoContext(ctx interface{}, users ...interface{}) *mockISlackUserGroup_GetUsersInfoContext_Call {
 	return &mockISlackUserGroup_GetUsersInfoContext_Call{Call: _e.mock.On("GetUsersInfoContext",
 		append([]interface{}{ctx}, users...)...)}
@@ -204,9 +204,9 @@ type mockISlackUserGroup_UpdateUserGroupMembersContext_Call struct {
 }
 
 // UpdateUserGroupMembersContext is a helper method to define mock.On call
-//  - ctx context.Context
-//  - userGroup string
-//  - members string
+//   - ctx context.Context
+//   - userGroup string
+//   - members string
 func (_e *mockISlackUserGroup_Expecter) UpdateUserGroupMembersContext(ctx interface{}, userGroup interface{}, members interface{}) *mockISlackUserGroup_UpdateUserGroupMembersContext_Call {
 	return &mockISlackUserGroup_UpdateUserGroupMembersContext_Call{Call: _e.mock.On("UpdateUserGroupMembersContext", ctx, userGroup, members)}
 }

--- a/adapters/slack/usergroup/usergroup.go
+++ b/adapters/slack/usergroup/usergroup.go
@@ -47,8 +47,9 @@ import (
 	"strings"
 	"time"
 
-	gosync "github.com/ovotech/go-sync"
 	"github.com/slack-go/slack"
+
+	gosync "github.com/ovotech/go-sync"
 )
 
 /*

--- a/adapters/slack/usergroup/usergroup_internal_test.go
+++ b/adapters/slack/usergroup/usergroup_internal_test.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 	"testing"
 
-	gosync "github.com/ovotech/go-sync"
 	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	gosync "github.com/ovotech/go-sync"
 )
 
 func TestNew(t *testing.T) {

--- a/adapters/slack/usergroup/usergroup_test.go
+++ b/adapters/slack/usergroup/usergroup_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"log"
 
+	"github.com/slack-go/slack"
+
 	gosync "github.com/ovotech/go-sync"
 	"github.com/ovotech/go-sync/adapters/slack/usergroup"
-	"github.com/slack-go/slack"
 )
 
 func ExampleNew() {

--- a/mock_Adapter_test.go
+++ b/mock_Adapter_test.go
@@ -41,8 +41,8 @@ type MockAdapter_Add_Call struct {
 }
 
 // Add is a helper method to define mock.On call
-//  - ctx context.Context
-//  - things []string
+//   - ctx context.Context
+//   - things []string
 func (_e *MockAdapter_Expecter) Add(ctx interface{}, things interface{}) *MockAdapter_Add_Call {
 	return &MockAdapter_Add_Call{Call: _e.mock.On("Add", ctx, things)}
 }
@@ -88,7 +88,7 @@ type MockAdapter_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//  - ctx context.Context
+//   - ctx context.Context
 func (_e *MockAdapter_Expecter) Get(ctx interface{}) *MockAdapter_Get_Call {
 	return &MockAdapter_Get_Call{Call: _e.mock.On("Get", ctx)}
 }
@@ -125,8 +125,8 @@ type MockAdapter_Remove_Call struct {
 }
 
 // Remove is a helper method to define mock.On call
-//  - ctx context.Context
-//  - things []string
+//   - ctx context.Context
+//   - things []string
 func (_e *MockAdapter_Expecter) Remove(ctx interface{}, things interface{}) *MockAdapter_Remove_Call {
 	return &MockAdapter_Remove_Call{Call: _e.mock.On("Remove", ctx, things)}
 }

--- a/mock_Service_test.go
+++ b/mock_Service_test.go
@@ -41,8 +41,8 @@ type MockService_SyncWith_Call struct {
 }
 
 // SyncWith is a helper method to define mock.On call
-//  - ctx context.Context
-//  - adapter Adapter
+//   - ctx context.Context
+//   - adapter Adapter
 func (_e *MockService_Expecter) SyncWith(ctx interface{}, adapter interface{}) *MockService_SyncWith_Call {
 	return &MockService_SyncWith_Call{Call: _e.mock.On("SyncWith", ctx, adapter)}
 }


### PR DESCRIPTION
Dependencies in Make rely on lots of metadata from the filesystem to know whether or not rebuilding a given target is necessary.
Sentinel files help by getting in between these checks and bottlenecking the process in order to reduce the overall amount of checking required.
There is further reading in [this article](https://tech.davis-hansson.com/p/make/).

The overall flow in the Makefile is now leveraging dependencies and will flow forward starting from code generation, through unit tests and then linting, and finally running builds of all Go code.
Tools necessary for the various Makefile targets to run will be installed on-demand in the `hack/bin/` sub-directory within the project.

Other changes in this PR are (1) related bits of documentation, and (2) updates based on the new/updated tooling in place in the Makefile.