### PR TITLE
Add MuteUserNotFoundErr option for SAML discovery service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,8 +194,8 @@ generate: hack/bin/mockery ## Generate mocks.
 .PHONY: generate
 
 ci/tag-adapters: ## Tag all adapters with $RELEASE_VERSION environment variable. For use in CI.
-> for adapter in $(shell find adapters -depth 1 -type d); do
->   git tag $${adapter#*/}/$${RELEASE_VERSION:?}
+> for adapter in $(shell ls -d adapters/*); do
+>   git tag $${adapter}/$${RELEASE_VERSION:?}
 > done
 .PHONY: ci/tag-adapters
 

--- a/adapters/github/discovery/saml/saml_internal_test.go
+++ b/adapters/github/discovery/saml/saml_internal_test.go
@@ -2,14 +2,42 @@ package saml
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+func emailQueryFunc(names ...string) func(ctx context.Context, q interface{}, variables map[string]interface{}) {
+	return func(_ context.Context, query interface{}, variables map[string]interface{}) {
+		edges := make([]emailQueryEdge, 0)
+
+		for _, name := range names {
+			foo := emailQueryEdge{}
+			foo.Node.SamlIdentity.NameID = name
+			edges = append(edges, foo)
+		}
+
+		arg := query.(*emailQuery)
+		arg.Organization.SamlIdentityProvider.ExternalIdentities.Edges = edges
+	}
+}
+
+func usernameQueryFunc(names ...string) func(ctx context.Context, q interface{}, variables map[string]interface{}) {
+	return func(_ context.Context, query interface{}, variables map[string]interface{}) {
+		edges := make([]usernameQueryEdge, 0)
+
+		for _, name := range names {
+			foo := usernameQueryEdge{}
+			foo.Node.User.Login = name
+			edges = append(edges, foo)
+		}
+
+		arg := query.(*usernameQuery)
+		arg.Organization.SamlIdentityProvider.ExternalIdentities.Edges = edges
+	}
+}
 
 func TestNew(t *testing.T) {
 	t.Parallel()
@@ -22,115 +50,156 @@ func TestNew(t *testing.T) {
 	assert.Zero(t, gitHubClient.Calls)
 }
 
-func TestSaml_GetEmailFromUsername(t *testing.T) { //nolint:dupl
+//nolint:funlen
+func TestSaml_GetUsernameFromEmail(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.TODO()
 
-	gitHubClient := newMockIGitHubV4Saml(t)
-	discovery := New(nil, "test")
-	discovery.client = gitHubClient
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
 
-	queryFn := func(name string) func(ctx context.Context, q interface{}, variables map[string]interface{}) {
-		return func(ctx context.Context, query interface{}, variables map[string]interface{}) {
-			resp := fmt.Sprintf(`
-{
-  "Organization": {
-    "SamlIdentityProvider": {
-      "ExternalIdentities": {
-        "Edges": [
-          {
-            "Node": {
-              "SamlIdentity": {
-                "NameID": "%s"
-              }
-            }
-          }
-        ]
-      }
-    }
-  }
+		gitHubClient := newMockIGitHubV4Saml(t)
+		discovery := New(nil, "test")
+		discovery.client = gitHubClient
+		discovery.MuteUserNotFoundErr = false
+
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"email": githubv4.String("foo@email"), "org": githubv4.String("test"),
+		},
+		).Run(usernameQueryFunc("foo")).Return(nil) //nolint:contextcheck
+
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"email": githubv4.String("bar@email"), "org": githubv4.String("test"),
+		},
+		).Run(usernameQueryFunc("bar")).Return(nil) //nolint:contextcheck
+
+		usernames, err := discovery.GetUsernameFromEmail(ctx, []string{"foo@email", "bar@email"})
+
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, usernames, []string{"foo", "bar"})
+	})
+
+	t.Run("MuteUserNotFoundErr false returns error", func(t *testing.T) {
+		t.Parallel()
+
+		gitHubClient := newMockIGitHubV4Saml(t)
+		discovery := New(nil, "test")
+		discovery.client = gitHubClient
+		discovery.MuteUserNotFoundErr = false
+
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"email": githubv4.String("foo@email"), "org": githubv4.String("test"),
+		},
+		).Run(usernameQueryFunc("foo")).Return(nil) //nolint:contextcheck
+
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"email": githubv4.String("bar@email"), "org": githubv4.String("test"),
+		},
+		).Run(usernameQueryFunc()).Return(nil) //nolint:contextcheck
+
+		_, err := discovery.GetUsernameFromEmail(ctx, []string{"foo@email", "bar@email"})
+
+		assert.ErrorIs(t, err, ErrUserNotFound)
+	})
+
+	t.Run("MuteUserNotFoundErr true returns all non-failing results", func(t *testing.T) { //nolint: dupl
+		t.Parallel()
+
+		gitHubClient := newMockIGitHubV4Saml(t)
+		discovery := New(nil, "test")
+		discovery.client = gitHubClient
+		discovery.MuteUserNotFoundErr = true
+
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"email": githubv4.String("foo@email"), "org": githubv4.String("test"),
+		},
+		).Run(usernameQueryFunc("foo")).Return(nil) //nolint:contextcheck
+
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"email": githubv4.String("bar@email"), "org": githubv4.String("test"),
+		},
+		).Run(usernameQueryFunc()).Return(nil) //nolint:contextcheck
+
+		usernames, err := discovery.GetUsernameFromEmail(ctx, []string{"foo@email", "bar@email"})
+
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, usernames, []string{"foo"})
+	})
 }
-`, name)
-			arg := query.(*emailQuery)
-			err := json.Unmarshal([]byte(resp), arg)
 
-			assert.NoError(t, err)
-			assert.Equal(t, name,
-				arg.Organization.SamlIdentityProvider.ExternalIdentities.Edges[0].Node.SamlIdentity.NameID,
-			)
-		}
-	}
-
-	gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
-		"login": githubv4.String("foo"), "org": githubv4.String("test"),
-	},
-	).Run(queryFn("foo@email")).
-		Return(nil)
-	gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
-		"login": githubv4.String("bar"), "org": githubv4.String("test"),
-	},
-	).Run(queryFn("bar@email")).
-		Return(nil)
-
-	usernames, err := discovery.GetEmailFromUsername(ctx, []string{"foo", "bar"})
-
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, usernames, []string{"foo@email", "bar@email"})
-}
-
-func TestSaml_GetUsernameFromEmail(t *testing.T) { //nolint:dupl
+func TestSaml_GetEmailFromUsername(t *testing.T) { //nolint: funlen
 	t.Parallel()
 
 	ctx := context.TODO()
 
-	gitHubClient := newMockIGitHubV4Saml(t)
-	discovery := New(nil, "test")
-	discovery.client = gitHubClient
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
 
-	queryFn := func(name string) func(ctx context.Context, q interface{}, variables map[string]interface{}) {
-		return func(ctx context.Context, query interface{}, variables map[string]interface{}) {
-			resp := fmt.Sprintf(`
-{
-  "Organization": {
-    "SamlIdentityProvider": {
-      "ExternalIdentities": {
-        "Edges": [
-          {
-            "Node": {
-              "User": {
-                "Login": "%s"
-              }
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-`, name)
-			arg := query.(*usernameQuery)
-			err := json.Unmarshal([]byte(resp), arg)
+		gitHubClient := newMockIGitHubV4Saml(t)
+		discovery := New(nil, "test")
+		discovery.client = gitHubClient
 
-			assert.NoError(t, err)
-			assert.Equal(t, name,
-				arg.Organization.SamlIdentityProvider.ExternalIdentities.Edges[0].Node.User.Login,
-			)
-		}
-	}
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"login": githubv4.String("foo"), "org": githubv4.String("test"),
+		},
+		).Run(emailQueryFunc("foo@email")).Return(nil) //nolint:contextcheck
 
-	gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
-		"email": githubv4.String("foo@email"), "org": githubv4.String("test"),
-	},
-	).Run(queryFn("foo")).Return(nil)
-	gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
-		"email": githubv4.String("bar@email"), "org": githubv4.String("test"),
-	},
-	).Run(queryFn("bar")).
-		Return(nil)
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"login": githubv4.String("bar"), "org": githubv4.String("test"),
+		},
+		).Run(emailQueryFunc("bar@email")).Return(nil) //nolint:contextcheck
 
-	usernames, err := discovery.GetUsernameFromEmail(ctx, []string{"foo@email", "bar@email"})
+		usernames, err := discovery.GetEmailFromUsername(ctx, []string{"foo", "bar"})
 
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, usernames, []string{"foo", "bar"})
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, usernames, []string{"foo@email", "bar@email"})
+	})
+
+	t.Run("MuteUserNotFoundErr false returns error", func(t *testing.T) {
+		t.Parallel()
+
+		gitHubClient := newMockIGitHubV4Saml(t)
+		discovery := New(nil, "test")
+		discovery.client = gitHubClient
+		discovery.MuteUserNotFoundErr = false
+
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"login": githubv4.String("foo"), "org": githubv4.String("test"),
+		},
+		).Run(emailQueryFunc("foo@email")).Return(nil) //nolint:contextcheck
+
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"login": githubv4.String("bar"), "org": githubv4.String("test"),
+		},
+		).Run(emailQueryFunc()).Return(nil) //nolint:contextcheck
+
+		_, err := discovery.GetEmailFromUsername(ctx, []string{"foo", "bar"})
+
+		assert.ErrorIs(t, err, ErrUserNotFound)
+	})
+
+	t.Run("MuteUserNotFoundErr true returns all non-failing results", func(t *testing.T) { //nolint: dupl
+		t.Parallel()
+
+		gitHubClient := newMockIGitHubV4Saml(t)
+		discovery := New(nil, "test")
+		discovery.client = gitHubClient
+		discovery.MuteUserNotFoundErr = true
+
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"login": githubv4.String("foo"), "org": githubv4.String("test"),
+		},
+		).Run(emailQueryFunc("foo@email")).Return(nil) //nolint:contextcheck
+
+		gitHubClient.EXPECT().Query(ctx, mock.Anything, map[string]interface{}{
+			"login": githubv4.String("bar"), "org": githubv4.String("test"),
+		},
+		).Run(emailQueryFunc()).Return(nil) //nolint:contextcheck
+
+		usernames, err := discovery.GetEmailFromUsername(ctx, []string{"foo", "bar"})
+
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, usernames, []string{"foo@email"})
+	})
 }


### PR DESCRIPTION
`MuteUserNotFoundErr` mutes the error if a user cannot be found, and returns only a list of found users. It can also be set with the `SamlMuteUserNotFoundErr` config key in the Team adapter.