### PR TITLE
Fix Slack usergroup adapter

### DIFF
--- a/adapters/slack/usergroup/usergroup.go
+++ b/adapters/slack/usergroup/usergroup.go
@@ -225,6 +225,7 @@ func (u *UserGroup) Remove(ctx context.Context, emails []string) error {
 	if cpcty < 0 {
 		cpcty = 0
 	}
+
 	updatedUserGroup := make([]string, 0, cpcty)
 
 	for email, slackID := range u.cache {

--- a/adapters/slack/usergroup/usergroup.go
+++ b/adapters/slack/usergroup/usergroup.go
@@ -221,12 +221,18 @@ func (u *UserGroup) Remove(ctx context.Context, emails []string) error {
 	}
 
 	// Iterate over the cached map of emails to Slack IDs, and only include those that aren't in the removal map.
-	updatedUserGroup := make([]string, 0, len(u.cache)-len(emails))
+	cpcty := len(u.cache) - len(emails)
+	if cpcty < 0 {
+		cpcty = 0
+	}
+	updatedUserGroup := make([]string, 0, cpcty)
 
 	for email, slackID := range u.cache {
 		// Only include the Slack ID if it's not in the map of emails to remove.
 		if !mapOfEmailsToRemove[email] {
 			updatedUserGroup = append(updatedUserGroup, slackID)
+		} else {
+			delete(u.cache, email)
 		}
 	}
 

--- a/adapters/slack/usergroup/usergroup.go
+++ b/adapters/slack/usergroup/usergroup.go
@@ -182,8 +182,12 @@ func (u *UserGroup) Add(ctx context.Context, emails []string) error {
 		if err != nil {
 			return fmt.Errorf("slack.usergroup.add.getuserbyemail(%s) -> %w", email, err)
 		}
+
 		// Add the new email user IDs to the list.
 		updatedUserGroup = append(updatedUserGroup, user.ID)
+
+		// Add the new email user ID to the cache
+		u.cache[email] = user.ID
 
 		// Calls to GetUserByEmail are heavily rate limited, so sleep to avoid this.
 		time.Sleep(2 * time.Second) //nolint:gomnd

--- a/adapters/slack/usergroup/usergroup_integration_test.go
+++ b/adapters/slack/usergroup/usergroup_integration_test.go
@@ -13,9 +13,11 @@ import (
 	gosync "github.com/ovotech/go-sync"
 )
 
-var group = flag.String("group", "", "Enter the user group ID to adjust group membership of in the Integration test")
-var email = flag.String("email", "", "Enter the email of a user to add to the user group membership of in the Integration test")
-var key = os.Getenv("SLACK_API_KEY")
+var (
+	group = flag.String("group", "", "Enter the user group ID to adjust group membership of in the Integration test")
+	email = flag.String("email", "", "Enter the email of a user to add to the user group membership of in the Integration test")
+	key   = os.Getenv("SLACK_API_KEY")
+)
 
 func TestIntegration(t *testing.T) {
 	if *group == "" {

--- a/adapters/slack/usergroup/usergroup_integration_test.go
+++ b/adapters/slack/usergroup/usergroup_integration_test.go
@@ -1,0 +1,67 @@
+//go:build integration
+
+package usergroup
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	gosync "github.com/ovotech/go-sync"
+)
+
+var group = flag.String("group", "", "Enter the user group ID to adjust group membership of in the Integration test")
+var email = flag.String("email", "", "Enter the email of a user to add to the user group membership of in the Integration test")
+var key = os.Getenv("SLACK_API_KEY")
+
+func TestIntegration(t *testing.T) {
+	if *group == "" {
+		t.Fatalf("Required parameter 'group' is missing or empty.")
+	}
+
+	if *email == "" {
+		t.Fatalf("Required parameter 'email' is missing or empty.")
+	}
+
+	if key == "" {
+		t.Fatalf("Required environment variable 'SLACK_API_KEY' is missing or empty.")
+	}
+
+	ctx := context.TODO()
+	adapter, err := Init(ctx, map[gosync.ConfigKey]string{
+		UserGroupID: *group,
+		SlackAPIKey: key,
+	})
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	emails, err := adapter.Get(ctx)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	assert.NotContainsf(t, emails, *email, "Email %s already exists in the user group %s", *email, *group)
+
+	err = adapter.Add(ctx, []string{*email})
+	assert.NoError(t, err)
+
+	err = adapter.Remove(ctx, emails)
+	assert.NoError(t, err)
+
+	newemails, err := adapter.Get(ctx)
+	assert.NoError(t, err)
+	assert.Containsf(t, newemails, *email, "Email %s not found after adding it to the group", *email)
+
+	err = adapter.Add(ctx, emails)
+	assert.NoError(t, err)
+
+	err = adapter.Remove(ctx, []string{*email})
+	assert.NoError(t, err)
+
+	finalemails, err := adapter.Get(ctx)
+	assert.NoError(t, err)
+	assert.NotContainsf(t, finalemails, *email, "Email %s still exists after removing it from the group %s", *email, *group)
+}

--- a/adapters/slack/usergroup/usergroup_internal_test.go
+++ b/adapters/slack/usergroup/usergroup_internal_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package usergroup
 
 import (

--- a/adapters/slack/usergroup/usergroup_internal_test.go
+++ b/adapters/slack/usergroup/usergroup_internal_test.go
@@ -139,6 +139,8 @@ func TestUserGroup_Add(t *testing.T) {
 		err := adapter.Add(ctx, []string{"fizz@email", "buzz@email"})
 
 		require.NoError(t, err)
+		assert.Contains(t, adapter.cache, "fizz@email")
+		assert.Contains(t, adapter.cache, "buzz@email")
 	})
 }
 
@@ -181,6 +183,8 @@ func TestUserGroup_Remove(t *testing.T) {
 		err := adapter.Remove(ctx, []string{"bar@email"})
 
 		require.NoError(t, err)
+		assert.Contains(t, adapter.cache, "foo@email")
+		assert.NotContains(t, adapter.cache, "bar@email")
 	})
 
 	t.Run("Return/mute error if number of accounts reaches zero", func(t *testing.T) {

--- a/adapters/slack/usergroup/usergroup_test.go
+++ b/adapters/slack/usergroup/usergroup_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package usergroup_test
 
 import (


### PR DESCRIPTION
This PR fixes a bug in the Slack usergroup adapter that was causing issues when adding and removing users from a group in a single operation.

The `Add` and `Remove` methods rely on internal state of the adapter to understand what user IDs are to be sent to the API. This internal state is only updated on the `Get` method, not the `Add` or `Remove` methods. Thus, when calling `Add` and subsequently `Remove` (or vice-versa), the state is wrong and the adapter sends an incorrect set of IDs to the Slack API. This resulted is buggy behaviour causing users to be added and removed in quick succession.