### PR TITLE
Fix linter errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,24 +1,46 @@
+issues:
+  exclude-rules:
+    # Test functions tend to be quite long due to the large amount of fixtures & test data etc.
+    - linters:
+        - funlen
+      path: _test\.go
+      text: "is too long"
+    # There's no need to wrap errors in a test.
+    - linters:
+        - wrapcheck
+      path: _test\.go
+      text: "error returned from external package is unwrapped"
+
 linters:
   enable-all: true
   disable:
-    - deadcode # deprecated
+    # tmpfix - currently breaking things
+    - musttag
+
     - depguard
     - exhaustruct
-    - exhaustivestruct # deprecated
     - forcetypeassert
-    - golint # deprecated
-    - gomodguard
+    - godox
     - gomoddirectives
-    - ifshort # deprecated
-    - interfacer # deprecated
-    - maligned # deprecated
-    - nosnakecase # deprecated
-    - rowserrcheck # disabled because of generics
-    - scopelint # deprecated
-    - structcheck # deprecated
-    - testableexamples # deprecated
+    - gomodguard
+    - ireturn
     - varcheck
-    - wastedassign # disabled because of generics
+
+    # deprecated
+    - deadcode
+    - exhaustivestruct
+    - golint
+    - ifshort
+    - interfacer
+    - maligned
+    - nosnakecase
+    - scopelint
+    - structcheck
+    - testableexamples
+
+    # disabled because of generics
+    - rowserrcheck
+    - wastedassign
 
 linters-settings:
   gomoddirectives:
@@ -34,9 +56,15 @@ linters-settings:
     skip-generated: true
     custom-order: true
 
-  varnamelen:
-    ignore-names:
-      - ID
+  revive:
+    confidence: 0.1
+    severity: warning
+    rules:
+      - name: exported
+        severity: error
+        disabled: false
+        arguments:
+          - checkPrivateReceivers
 
 run:
-  timeout: 30m
+  timeout: "5m"

--- a/.taskfiles/tools/golangci-lint.yml
+++ b/.taskfiles/tools/golangci-lint.yml
@@ -40,4 +40,4 @@ tasks:
       - ./**/*.go
     cmds:
       - task: golangci-lint
-        vars: { ARGS: '--fix --timeout=10m' }
+        vars: { ARGS: '--fix' }

--- a/adapters/azuread/groupmembership/groupmembership.go
+++ b/adapters/azuread/groupmembership/groupmembership.go
@@ -45,14 +45,20 @@ type iClient interface {
 var _ iClient = &msgraphsdkgo.GraphServiceClient{}
 
 type iGroupClient interface {
-	Get(context.Context, *groups.GroupsRequestBuilderGetRequestConfiguration) (models.GroupCollectionResponseable, error)
-	ByGroupId(string) *groups.GroupItemRequestBuilder
+	Get(
+		ctx context.Context,
+		config *groups.GroupsRequestBuilderGetRequestConfiguration,
+	) (models.GroupCollectionResponseable, error)
+	ByGroupId(id string) *groups.GroupItemRequestBuilder
 }
 
 var _ iGroupClient = &groups.GroupsRequestBuilder{}
 
 type iUserClient interface {
-	Get(context.Context, *users.UsersRequestBuilderGetRequestConfiguration) (models.UserCollectionResponseable, error)
+	Get(
+		ctx context.Context,
+		config *users.UsersRequestBuilderGetRequestConfiguration,
+	) (models.UserCollectionResponseable, error)
 }
 
 var _ iUserClient = &users.UsersRequestBuilder{}

--- a/adapters/azuread/groupmembership/groupmembership_integration_test.go
+++ b/adapters/azuread/groupmembership/groupmembership_integration_test.go
@@ -29,23 +29,23 @@ func TestIntegration(t *testing.T) {
 	adapter, err := Init(ctx, map[gosync.ConfigKey]string{
 		GroupName: *group,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	emails, err := adapter.Get(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotContainsf(t, emails, *email, "Email %s already exists in the group %s", *email, *group)
 
 	err = adapter.Add(ctx, []string{*email})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	emails, err = adapter.Get(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Containsf(t, emails, *email, "Email %s not found after adding it to the group", *email)
 
 	err = adapter.Remove(ctx, []string{*email})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	emails, err = adapter.Get(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotContainsf(t, emails, *email, "Email %s still exists after removing it from the group %s", *email, *group)
 }

--- a/adapters/azuread/groupmembership/groupmembership_internal_test.go
+++ b/adapters/azuread/groupmembership/groupmembership_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	gosync "github.com/ovotech/go-sync"
 )
@@ -32,7 +33,7 @@ func TestInit(t *testing.T) {
 			GroupName: "example",
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.IsType(t, &GroupMembership{}, adapter)
 		assert.Equal(t, "example", adapter.group)
 	})
@@ -45,7 +46,7 @@ func TestInit(t *testing.T) {
 
 			_, err := Init(ctx, map[gosync.ConfigKey]string{})
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
 		})
 	})
 }
@@ -87,7 +88,7 @@ func Test_resolveGroupID(t *testing.T) {
 
 		gid, err := resolveGroupID(ctx, client, group)
 		assert.Empty(t, gid)
-		assert.ErrorIs(t, err, ErrNoResults)
+		require.ErrorIs(t, err, ErrNoResults)
 	})
 
 	t.Run("one found", func(t *testing.T) {
@@ -97,7 +98,7 @@ func Test_resolveGroupID(t *testing.T) {
 
 		gid, err := resolveGroupID(ctx, client, group)
 		assert.Contains(t, gid, "00000001-0000-0000-0000-000123456789")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("multiple found", func(t *testing.T) {
@@ -110,7 +111,7 @@ func Test_resolveGroupID(t *testing.T) {
 
 		gid, err := resolveGroupID(ctx, client, group)
 		assert.Empty(t, gid)
-		assert.ErrorIs(t, err, ErrTooManyResults)
+		require.ErrorIs(t, err, ErrTooManyResults)
 	})
 }
 
@@ -151,7 +152,7 @@ func Test_resolveUserID(t *testing.T) {
 
 		gid, err := resolveUserID(ctx, client, email)
 		assert.Empty(t, gid)
-		assert.ErrorIs(t, err, ErrNoResults)
+		require.ErrorIs(t, err, ErrNoResults)
 	})
 
 	t.Run("one found", func(t *testing.T) {
@@ -161,7 +162,7 @@ func Test_resolveUserID(t *testing.T) {
 
 		gid, err := resolveUserID(ctx, client, email)
 		assert.Contains(t, gid, "00000001-1000-0000-0000-000123456789")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("multiple found", func(t *testing.T) {
@@ -171,7 +172,7 @@ func Test_resolveUserID(t *testing.T) {
 
 		gid, err := resolveUserID(ctx, client, email)
 		assert.Empty(t, gid)
-		assert.ErrorIs(t, err, ErrTooManyResults)
+		require.ErrorIs(t, err, ErrTooManyResults)
 	})
 }
 
@@ -229,11 +230,10 @@ func TestGroupMembership_Get(t *testing.T) {
 	}
 
 	out, err := adapter.Get(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, out, expected)
 }
 
-//nolint:funlen
 func TestGroupMembership_Add(t *testing.T) {
 	t.Parallel()
 
@@ -312,10 +312,9 @@ func TestGroupMembership_Add(t *testing.T) {
 
 	expected := []string{userMail1, userMail2}
 	err := adapter.Add(ctx, expected)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
-//nolint:funlen
 func TestGroupMembership_Remove(t *testing.T) {
 	t.Parallel()
 
@@ -384,7 +383,7 @@ func TestGroupMembership_Remove(t *testing.T) {
 	}
 
 	err := adapter.Remove(ctx, []string{userMail1, userMail2})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 type MockRequestAdapter struct {
@@ -467,11 +466,11 @@ func (r *MockRequestAdapter) GetSerializationWriterFactory() serialization.Seria
 func (r *MockRequestAdapter) EnableBackingStore(_ store.BackingStoreFactory) {
 }
 
-//nolint:revive,stylecheck
+//nolint:stylecheck
 func (r *MockRequestAdapter) SetBaseUrl(_ string) {
 }
 
-//nolint:revive,stylecheck
+//nolint:stylecheck
 func (r *MockRequestAdapter) GetBaseUrl() string {
 	return ""
 }

--- a/adapters/azuread/groupmembership/mock_iClient_test.go
+++ b/adapters/azuread/groupmembership/mock_iClient_test.go
@@ -24,6 +24,10 @@ func (_m *mockIClient) EXPECT() *mockIClient_Expecter {
 func (_m *mockIClient) GetAdapter() abstractions.RequestAdapter {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAdapter")
+	}
+
 	var r0 abstractions.RequestAdapter
 	if rf, ok := ret.Get(0).(func() abstractions.RequestAdapter); ok {
 		r0 = rf()

--- a/adapters/azuread/groupmembership/mock_iGroupClient_test.go
+++ b/adapters/azuread/groupmembership/mock_iGroupClient_test.go
@@ -23,13 +23,17 @@ func (_m *mockIGroupClient) EXPECT() *mockIGroupClient_Expecter {
 	return &mockIGroupClient_Expecter{mock: &_m.Mock}
 }
 
-// ByGroupId provides a mock function with given fields: _a0
-func (_m *mockIGroupClient) ByGroupId(_a0 string) *groups.GroupItemRequestBuilder {
-	ret := _m.Called(_a0)
+// ByGroupId provides a mock function with given fields: id
+func (_m *mockIGroupClient) ByGroupId(id string) *groups.GroupItemRequestBuilder {
+	ret := _m.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ByGroupId")
+	}
 
 	var r0 *groups.GroupItemRequestBuilder
 	if rf, ok := ret.Get(0).(func(string) *groups.GroupItemRequestBuilder); ok {
-		r0 = rf(_a0)
+		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*groups.GroupItemRequestBuilder)
@@ -45,12 +49,12 @@ type mockIGroupClient_ByGroupId_Call struct {
 }
 
 // ByGroupId is a helper method to define mock.On call
-//   - _a0 string
-func (_e *mockIGroupClient_Expecter) ByGroupId(_a0 interface{}) *mockIGroupClient_ByGroupId_Call {
-	return &mockIGroupClient_ByGroupId_Call{Call: _e.mock.On("ByGroupId", _a0)}
+//   - id string
+func (_e *mockIGroupClient_Expecter) ByGroupId(id interface{}) *mockIGroupClient_ByGroupId_Call {
+	return &mockIGroupClient_ByGroupId_Call{Call: _e.mock.On("ByGroupId", id)}
 }
 
-func (_c *mockIGroupClient_ByGroupId_Call) Run(run func(_a0 string)) *mockIGroupClient_ByGroupId_Call {
+func (_c *mockIGroupClient_ByGroupId_Call) Run(run func(id string)) *mockIGroupClient_ByGroupId_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(string))
 	})
@@ -67,17 +71,21 @@ func (_c *mockIGroupClient_ByGroupId_Call) RunAndReturn(run func(string) *groups
 	return _c
 }
 
-// Get provides a mock function with given fields: _a0, _a1
-func (_m *mockIGroupClient) Get(_a0 context.Context, _a1 *groups.GroupsRequestBuilderGetRequestConfiguration) (models.GroupCollectionResponseable, error) {
-	ret := _m.Called(_a0, _a1)
+// Get provides a mock function with given fields: ctx, config
+func (_m *mockIGroupClient) Get(ctx context.Context, config *groups.GroupsRequestBuilderGetRequestConfiguration) (models.GroupCollectionResponseable, error) {
+	ret := _m.Called(ctx, config)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
 
 	var r0 models.GroupCollectionResponseable
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *groups.GroupsRequestBuilderGetRequestConfiguration) (models.GroupCollectionResponseable, error)); ok {
-		return rf(_a0, _a1)
+		return rf(ctx, config)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, *groups.GroupsRequestBuilderGetRequestConfiguration) models.GroupCollectionResponseable); ok {
-		r0 = rf(_a0, _a1)
+		r0 = rf(ctx, config)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(models.GroupCollectionResponseable)
@@ -85,7 +93,7 @@ func (_m *mockIGroupClient) Get(_a0 context.Context, _a1 *groups.GroupsRequestBu
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *groups.GroupsRequestBuilderGetRequestConfiguration) error); ok {
-		r1 = rf(_a0, _a1)
+		r1 = rf(ctx, config)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -99,13 +107,13 @@ type mockIGroupClient_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *groups.GroupsRequestBuilderGetRequestConfiguration
-func (_e *mockIGroupClient_Expecter) Get(_a0 interface{}, _a1 interface{}) *mockIGroupClient_Get_Call {
-	return &mockIGroupClient_Get_Call{Call: _e.mock.On("Get", _a0, _a1)}
+//   - ctx context.Context
+//   - config *groups.GroupsRequestBuilderGetRequestConfiguration
+func (_e *mockIGroupClient_Expecter) Get(ctx interface{}, config interface{}) *mockIGroupClient_Get_Call {
+	return &mockIGroupClient_Get_Call{Call: _e.mock.On("Get", ctx, config)}
 }
 
-func (_c *mockIGroupClient_Get_Call) Run(run func(_a0 context.Context, _a1 *groups.GroupsRequestBuilderGetRequestConfiguration)) *mockIGroupClient_Get_Call {
+func (_c *mockIGroupClient_Get_Call) Run(run func(ctx context.Context, config *groups.GroupsRequestBuilderGetRequestConfiguration)) *mockIGroupClient_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(*groups.GroupsRequestBuilderGetRequestConfiguration))
 	})

--- a/adapters/azuread/groupmembership/mock_iUserClient_test.go
+++ b/adapters/azuread/groupmembership/mock_iUserClient_test.go
@@ -23,17 +23,21 @@ func (_m *mockIUserClient) EXPECT() *mockIUserClient_Expecter {
 	return &mockIUserClient_Expecter{mock: &_m.Mock}
 }
 
-// Get provides a mock function with given fields: _a0, _a1
-func (_m *mockIUserClient) Get(_a0 context.Context, _a1 *users.UsersRequestBuilderGetRequestConfiguration) (models.UserCollectionResponseable, error) {
-	ret := _m.Called(_a0, _a1)
+// Get provides a mock function with given fields: ctx, config
+func (_m *mockIUserClient) Get(ctx context.Context, config *users.UsersRequestBuilderGetRequestConfiguration) (models.UserCollectionResponseable, error) {
+	ret := _m.Called(ctx, config)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
 
 	var r0 models.UserCollectionResponseable
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *users.UsersRequestBuilderGetRequestConfiguration) (models.UserCollectionResponseable, error)); ok {
-		return rf(_a0, _a1)
+		return rf(ctx, config)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, *users.UsersRequestBuilderGetRequestConfiguration) models.UserCollectionResponseable); ok {
-		r0 = rf(_a0, _a1)
+		r0 = rf(ctx, config)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(models.UserCollectionResponseable)
@@ -41,7 +45,7 @@ func (_m *mockIUserClient) Get(_a0 context.Context, _a1 *users.UsersRequestBuild
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *users.UsersRequestBuilderGetRequestConfiguration) error); ok {
-		r1 = rf(_a0, _a1)
+		r1 = rf(ctx, config)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -55,13 +59,13 @@ type mockIUserClient_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *users.UsersRequestBuilderGetRequestConfiguration
-func (_e *mockIUserClient_Expecter) Get(_a0 interface{}, _a1 interface{}) *mockIUserClient_Get_Call {
-	return &mockIUserClient_Get_Call{Call: _e.mock.On("Get", _a0, _a1)}
+//   - ctx context.Context
+//   - config *users.UsersRequestBuilderGetRequestConfiguration
+func (_e *mockIUserClient_Expecter) Get(ctx interface{}, config interface{}) *mockIUserClient_Get_Call {
+	return &mockIUserClient_Get_Call{Call: _e.mock.On("Get", ctx, config)}
 }
 
-func (_c *mockIUserClient_Get_Call) Run(run func(_a0 context.Context, _a1 *users.UsersRequestBuilderGetRequestConfiguration)) *mockIUserClient_Get_Call {
+func (_c *mockIUserClient_Get_Call) Run(run func(ctx context.Context, config *users.UsersRequestBuilderGetRequestConfiguration)) *mockIUserClient_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(*users.UsersRequestBuilderGetRequestConfiguration))
 	})

--- a/adapters/azuread/user/mock_iClient_test.go
+++ b/adapters/azuread/user/mock_iClient_test.go
@@ -25,6 +25,10 @@ func (_m *mockIClient) EXPECT() *mockIClient_Expecter {
 func (_m *mockIClient) GetAdapter() abstractions.RequestAdapter {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAdapter")
+	}
+
 	var r0 abstractions.RequestAdapter
 	if rf, ok := ret.Get(0).(func() abstractions.RequestAdapter); ok {
 		r0 = rf()
@@ -67,6 +71,10 @@ func (_c *mockIClient_GetAdapter_Call) RunAndReturn(run func() abstractions.Requ
 // Users provides a mock function with given fields:
 func (_m *mockIClient) Users() *users.UsersRequestBuilder {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Users")
+	}
 
 	var r0 *users.UsersRequestBuilder
 	if rf, ok := ret.Get(0).(func() *users.UsersRequestBuilder); ok {

--- a/adapters/azuread/user/mock_iUser_test.go
+++ b/adapters/azuread/user/mock_iUser_test.go
@@ -23,17 +23,21 @@ func (_m *mockIUser) EXPECT() *mockIUser_Expecter {
 	return &mockIUser_Expecter{mock: &_m.Mock}
 }
 
-// Get provides a mock function with given fields: _a0, _a1
-func (_m *mockIUser) Get(_a0 context.Context, _a1 *users.UsersRequestBuilderGetRequestConfiguration) (models.UserCollectionResponseable, error) {
-	ret := _m.Called(_a0, _a1)
+// Get provides a mock function with given fields: ctx, config
+func (_m *mockIUser) Get(ctx context.Context, config *users.UsersRequestBuilderGetRequestConfiguration) (models.UserCollectionResponseable, error) {
+	ret := _m.Called(ctx, config)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
 
 	var r0 models.UserCollectionResponseable
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *users.UsersRequestBuilderGetRequestConfiguration) (models.UserCollectionResponseable, error)); ok {
-		return rf(_a0, _a1)
+		return rf(ctx, config)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, *users.UsersRequestBuilderGetRequestConfiguration) models.UserCollectionResponseable); ok {
-		r0 = rf(_a0, _a1)
+		r0 = rf(ctx, config)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(models.UserCollectionResponseable)
@@ -41,7 +45,7 @@ func (_m *mockIUser) Get(_a0 context.Context, _a1 *users.UsersRequestBuilderGetR
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *users.UsersRequestBuilderGetRequestConfiguration) error); ok {
-		r1 = rf(_a0, _a1)
+		r1 = rf(ctx, config)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -55,13 +59,13 @@ type mockIUser_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *users.UsersRequestBuilderGetRequestConfiguration
-func (_e *mockIUser_Expecter) Get(_a0 interface{}, _a1 interface{}) *mockIUser_Get_Call {
-	return &mockIUser_Get_Call{Call: _e.mock.On("Get", _a0, _a1)}
+//   - ctx context.Context
+//   - config *users.UsersRequestBuilderGetRequestConfiguration
+func (_e *mockIUser_Expecter) Get(ctx interface{}, config interface{}) *mockIUser_Get_Call {
+	return &mockIUser_Get_Call{Call: _e.mock.On("Get", ctx, config)}
 }
 
-func (_c *mockIUser_Get_Call) Run(run func(_a0 context.Context, _a1 *users.UsersRequestBuilderGetRequestConfiguration)) *mockIUser_Get_Call {
+func (_c *mockIUser_Get_Call) Run(run func(ctx context.Context, config *users.UsersRequestBuilderGetRequestConfiguration)) *mockIUser_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(*users.UsersRequestBuilderGetRequestConfiguration))
 	})

--- a/adapters/azuread/user/user.go
+++ b/adapters/azuread/user/user.go
@@ -42,7 +42,10 @@ See the [reference] for more information on filter queries.
 const Filter gosync.ConfigKey = "filter"
 
 type iUser interface {
-	Get(context.Context, *users.UsersRequestBuilderGetRequestConfiguration) (models.UserCollectionResponseable, error)
+	Get(
+		ctx context.Context,
+		config *users.UsersRequestBuilderGetRequestConfiguration,
+	) (models.UserCollectionResponseable, error)
 }
 
 type iClient interface {

--- a/adapters/azuread/user/user_integration_test.go
+++ b/adapters/azuread/user/user_integration_test.go
@@ -20,9 +20,9 @@ func TestIntegration(t *testing.T) {
 	adapter, err := Init(ctx, map[gosync.ConfigKey]string{
 		Filter: fmt.Sprintf("mail eq '%s'", *email),
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	emails, err := adapter.Get(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, emails, []string{*email})
 }

--- a/adapters/azuread/user/user_internal_test.go
+++ b/adapters/azuread/user/user_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	gosync "github.com/ovotech/go-sync"
 )
@@ -95,11 +96,11 @@ func (r *MockRequestAdapter) GetSerializationWriterFactory() serialization.Seria
 func (r *MockRequestAdapter) EnableBackingStore(_ store.BackingStoreFactory) {
 }
 
-//nolint:revive,stylecheck
+//nolint:stylecheck
 func (r *MockRequestAdapter) SetBaseUrl(_ string) {
 }
 
-//nolint:revive,stylecheck
+//nolint:stylecheck
 func (r *MockRequestAdapter) GetBaseUrl() string {
 	return ""
 }
@@ -115,7 +116,7 @@ func TestTeam_Get(t *testing.T) {
 	mockClient.EXPECT().GetAdapter().Return(&MockRequestAdapter{})
 
 	adapter, err := Init(context.TODO(), nil, WithClient(mockClient))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	adapter.users = mockUser
 
@@ -149,11 +150,11 @@ func TestTeam_Add(t *testing.T) {
 	mockClient := newMockIClient(t)
 
 	adapter, err := Init(context.TODO(), nil, WithClient(mockClient))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = adapter.Add(context.TODO(), []string{"foo@email", "bar@email"})
 
-	assert.ErrorIs(t, err, gosync.ErrReadOnly)
+	require.ErrorIs(t, err, gosync.ErrReadOnly)
 }
 
 func TestTeam_Remove(t *testing.T) {
@@ -162,11 +163,11 @@ func TestTeam_Remove(t *testing.T) {
 	mockClient := newMockIClient(t)
 
 	adapter, err := Init(context.TODO(), nil, WithClient(mockClient))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = adapter.Remove(context.TODO(), []string{"foo@email", "bar@email"})
 
-	assert.ErrorIs(t, err, gosync.ErrReadOnly)
+	require.ErrorIs(t, err, gosync.ErrReadOnly)
 }
 
 func Test_isAdvancedQuery(t *testing.T) {
@@ -220,7 +221,7 @@ func TestInit(t *testing.T) {
 			Filter: "filter",
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.IsType(t, &User{}, adapter)
 		assert.Equal(t, "filter", adapter.filter)
 	})
@@ -233,7 +234,7 @@ func TestInit(t *testing.T) {
 
 			adapter, err := Init(ctx, map[gosync.ConfigKey]string{})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, "", adapter.filter)
 		})
 	})

--- a/adapters/github/discovery/discovery.go
+++ b/adapters/github/discovery/discovery.go
@@ -5,6 +5,6 @@ import "context"
 // GitHubDiscovery is required because there are multiple ways to convert a GitHub email into a username.
 // At OVO we use SAML, but other organisations may use public emails or another mechanism.
 type GitHubDiscovery interface {
-	GetUsernameFromEmail(context.Context, []string) ([]string, error)
-	GetEmailFromUsername(context.Context, []string) ([]string, error)
+	GetUsernameFromEmail(ctx context.Context, emails []string) ([]string, error)
+	GetEmailFromUsername(ctx context.Context, usernames []string) ([]string, error)
 }

--- a/adapters/github/discovery/mock_GitHubDiscovery_test.go
+++ b/adapters/github/discovery/mock_GitHubDiscovery_test.go
@@ -21,17 +21,21 @@ func (_m *MockGitHubDiscovery) EXPECT() *MockGitHubDiscovery_Expecter {
 	return &MockGitHubDiscovery_Expecter{mock: &_m.Mock}
 }
 
-// GetEmailFromUsername provides a mock function with given fields: _a0, _a1
-func (_m *MockGitHubDiscovery) GetEmailFromUsername(_a0 context.Context, _a1 []string) ([]string, error) {
-	ret := _m.Called(_a0, _a1)
+// GetEmailFromUsername provides a mock function with given fields: ctx, usernames
+func (_m *MockGitHubDiscovery) GetEmailFromUsername(ctx context.Context, usernames []string) ([]string, error) {
+	ret := _m.Called(ctx, usernames)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEmailFromUsername")
+	}
 
 	var r0 []string
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, []string) ([]string, error)); ok {
-		return rf(_a0, _a1)
+		return rf(ctx, usernames)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, []string) []string); ok {
-		r0 = rf(_a0, _a1)
+		r0 = rf(ctx, usernames)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -39,7 +43,7 @@ func (_m *MockGitHubDiscovery) GetEmailFromUsername(_a0 context.Context, _a1 []s
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
-		r1 = rf(_a0, _a1)
+		r1 = rf(ctx, usernames)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -53,13 +57,13 @@ type MockGitHubDiscovery_GetEmailFromUsername_Call struct {
 }
 
 // GetEmailFromUsername is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 []string
-func (_e *MockGitHubDiscovery_Expecter) GetEmailFromUsername(_a0 interface{}, _a1 interface{}) *MockGitHubDiscovery_GetEmailFromUsername_Call {
-	return &MockGitHubDiscovery_GetEmailFromUsername_Call{Call: _e.mock.On("GetEmailFromUsername", _a0, _a1)}
+//   - ctx context.Context
+//   - usernames []string
+func (_e *MockGitHubDiscovery_Expecter) GetEmailFromUsername(ctx interface{}, usernames interface{}) *MockGitHubDiscovery_GetEmailFromUsername_Call {
+	return &MockGitHubDiscovery_GetEmailFromUsername_Call{Call: _e.mock.On("GetEmailFromUsername", ctx, usernames)}
 }
 
-func (_c *MockGitHubDiscovery_GetEmailFromUsername_Call) Run(run func(_a0 context.Context, _a1 []string)) *MockGitHubDiscovery_GetEmailFromUsername_Call {
+func (_c *MockGitHubDiscovery_GetEmailFromUsername_Call) Run(run func(ctx context.Context, usernames []string)) *MockGitHubDiscovery_GetEmailFromUsername_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].([]string))
 	})
@@ -76,17 +80,21 @@ func (_c *MockGitHubDiscovery_GetEmailFromUsername_Call) RunAndReturn(run func(c
 	return _c
 }
 
-// GetUsernameFromEmail provides a mock function with given fields: _a0, _a1
-func (_m *MockGitHubDiscovery) GetUsernameFromEmail(_a0 context.Context, _a1 []string) ([]string, error) {
-	ret := _m.Called(_a0, _a1)
+// GetUsernameFromEmail provides a mock function with given fields: ctx, emails
+func (_m *MockGitHubDiscovery) GetUsernameFromEmail(ctx context.Context, emails []string) ([]string, error) {
+	ret := _m.Called(ctx, emails)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsernameFromEmail")
+	}
 
 	var r0 []string
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, []string) ([]string, error)); ok {
-		return rf(_a0, _a1)
+		return rf(ctx, emails)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, []string) []string); ok {
-		r0 = rf(_a0, _a1)
+		r0 = rf(ctx, emails)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -94,7 +102,7 @@ func (_m *MockGitHubDiscovery) GetUsernameFromEmail(_a0 context.Context, _a1 []s
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
-		r1 = rf(_a0, _a1)
+		r1 = rf(ctx, emails)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -108,13 +116,13 @@ type MockGitHubDiscovery_GetUsernameFromEmail_Call struct {
 }
 
 // GetUsernameFromEmail is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 []string
-func (_e *MockGitHubDiscovery_Expecter) GetUsernameFromEmail(_a0 interface{}, _a1 interface{}) *MockGitHubDiscovery_GetUsernameFromEmail_Call {
-	return &MockGitHubDiscovery_GetUsernameFromEmail_Call{Call: _e.mock.On("GetUsernameFromEmail", _a0, _a1)}
+//   - ctx context.Context
+//   - emails []string
+func (_e *MockGitHubDiscovery_Expecter) GetUsernameFromEmail(ctx interface{}, emails interface{}) *MockGitHubDiscovery_GetUsernameFromEmail_Call {
+	return &MockGitHubDiscovery_GetUsernameFromEmail_Call{Call: _e.mock.On("GetUsernameFromEmail", ctx, emails)}
 }
 
-func (_c *MockGitHubDiscovery_GetUsernameFromEmail_Call) Run(run func(_a0 context.Context, _a1 []string)) *MockGitHubDiscovery_GetUsernameFromEmail_Call {
+func (_c *MockGitHubDiscovery_GetUsernameFromEmail_Call) Run(run func(ctx context.Context, emails []string)) *MockGitHubDiscovery_GetUsernameFromEmail_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].([]string))
 	})

--- a/adapters/github/discovery/saml/mock_iGitHubV4Saml_test.go
+++ b/adapters/github/discovery/saml/mock_iGitHubV4Saml_test.go
@@ -25,6 +25,10 @@ func (_m *mockIGitHubV4Saml) EXPECT() *mockIGitHubV4Saml_Expecter {
 func (_m *mockIGitHubV4Saml) Query(ctx context.Context, q interface{}, variables map[string]interface{}) error {
 	ret := _m.Called(ctx, q, variables)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Query")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, interface{}, map[string]interface{}) error); ok {
 		r0 = rf(ctx, q, variables)

--- a/adapters/github/discovery/saml/saml_internal_test.go
+++ b/adapters/github/discovery/saml/saml_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func emailQueryFunc(names ...string) func(ctx context.Context, q interface{}, variables map[string]interface{}) {
@@ -50,7 +51,6 @@ func TestNew(t *testing.T) {
 	assert.Zero(t, gitHubClient.Calls)
 }
 
-//nolint:funlen
 func TestSaml_GetUsernameFromEmail(t *testing.T) {
 	t.Parallel()
 
@@ -76,7 +76,7 @@ func TestSaml_GetUsernameFromEmail(t *testing.T) {
 
 		usernames, err := discovery.GetUsernameFromEmail(ctx, []string{"foo@email", "bar@email"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.ElementsMatch(t, usernames, []string{"foo", "bar"})
 	})
 
@@ -100,7 +100,7 @@ func TestSaml_GetUsernameFromEmail(t *testing.T) {
 
 		_, err := discovery.GetUsernameFromEmail(ctx, []string{"foo@email", "bar@email"})
 
-		assert.ErrorIs(t, err, ErrUserNotFound)
+		require.ErrorIs(t, err, ErrUserNotFound)
 	})
 
 	t.Run("MuteUserNotFoundErr true returns all non-failing results", func(t *testing.T) { //nolint: dupl
@@ -123,12 +123,12 @@ func TestSaml_GetUsernameFromEmail(t *testing.T) {
 
 		usernames, err := discovery.GetUsernameFromEmail(ctx, []string{"foo@email", "bar@email"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.ElementsMatch(t, usernames, []string{"foo"})
 	})
 }
 
-func TestSaml_GetEmailFromUsername(t *testing.T) { //nolint: funlen
+func TestSaml_GetEmailFromUsername(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.TODO()
@@ -152,7 +152,7 @@ func TestSaml_GetEmailFromUsername(t *testing.T) { //nolint: funlen
 
 		usernames, err := discovery.GetEmailFromUsername(ctx, []string{"foo", "bar"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.ElementsMatch(t, usernames, []string{"foo@email", "bar@email"})
 	})
 
@@ -176,7 +176,7 @@ func TestSaml_GetEmailFromUsername(t *testing.T) { //nolint: funlen
 
 		_, err := discovery.GetEmailFromUsername(ctx, []string{"foo", "bar"})
 
-		assert.ErrorIs(t, err, ErrUserNotFound)
+		require.ErrorIs(t, err, ErrUserNotFound)
 	})
 
 	t.Run("MuteUserNotFoundErr true returns all non-failing results", func(t *testing.T) { //nolint: dupl
@@ -199,7 +199,7 @@ func TestSaml_GetEmailFromUsername(t *testing.T) { //nolint: funlen
 
 		usernames, err := discovery.GetEmailFromUsername(ctx, []string{"foo", "bar"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.ElementsMatch(t, usernames, []string{"foo@email"})
 	})
 }

--- a/adapters/github/team/mock_iGitHubTeam_test.go
+++ b/adapters/github/team/mock_iGitHubTeam_test.go
@@ -26,6 +26,10 @@ func (_m *mockIGitHubTeam) EXPECT() *mockIGitHubTeam_Expecter {
 func (_m *mockIGitHubTeam) AddTeamMembershipBySlug(ctx context.Context, org string, slug string, user string, opts *github.TeamAddTeamMembershipOptions) (*github.Membership, *github.Response, error) {
 	ret := _m.Called(ctx, org, slug, user, opts)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AddTeamMembershipBySlug")
+	}
+
 	var r0 *github.Membership
 	var r1 *github.Response
 	var r2 error
@@ -93,6 +97,10 @@ func (_c *mockIGitHubTeam_AddTeamMembershipBySlug_Call) RunAndReturn(run func(co
 func (_m *mockIGitHubTeam) ListTeamMembersBySlug(ctx context.Context, org string, slug string, opts *github.TeamListTeamMembersOptions) ([]*github.User, *github.Response, error) {
 	ret := _m.Called(ctx, org, slug, opts)
 
+	if len(ret) == 0 {
+		panic("no return value specified for ListTeamMembersBySlug")
+	}
+
 	var r0 []*github.User
 	var r1 *github.Response
 	var r2 error
@@ -158,6 +166,10 @@ func (_c *mockIGitHubTeam_ListTeamMembersBySlug_Call) RunAndReturn(run func(cont
 // RemoveTeamMembershipBySlug provides a mock function with given fields: ctx, org, slug, user
 func (_m *mockIGitHubTeam) RemoveTeamMembershipBySlug(ctx context.Context, org string, slug string, user string) (*github.Response, error) {
 	ret := _m.Called(ctx, org, slug, user)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveTeamMembershipBySlug")
+	}
 
 	var r0 *github.Response
 	var r1 error

--- a/adapters/github/team/team_internal_test.go
+++ b/adapters/github/team/team_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-github/v47/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
 	gosync "github.com/ovotech/go-sync"
@@ -50,7 +51,7 @@ func TestTeam_Get(t *testing.T) {
 
 	users, err := adapter.Get(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, users, []string{"foo@email", "bar@email"})
 	assert.Equal(t, map[string]string{"foo@email": "foo", "bar@email": "bar"}, adapter.cache)
 }
@@ -80,7 +81,7 @@ func TestTeam_Add(t *testing.T) {
 
 	err := adapter.Add(ctx, []string{"fizz@email", "buzz@email"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestTeam_Remove(t *testing.T) {
@@ -105,10 +106,9 @@ func TestTeam_Remove(t *testing.T) {
 
 	err := adapter.Remove(ctx, []string{"foo@email", "bar@email"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
-//nolint:funlen
 func TestInit(t *testing.T) {
 	t.Parallel()
 
@@ -124,7 +124,7 @@ func TestInit(t *testing.T) {
 			DiscoveryMechanism: "saml",
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.IsType(t, &Team{}, adapter)
 		assert.Equal(t, "org", adapter.org)
 		assert.Equal(t, "slug", adapter.slug)
@@ -143,8 +143,8 @@ func TestInit(t *testing.T) {
 				DiscoveryMechanism: "saml",
 			})
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-			assert.ErrorContains(t, err, GitHubToken)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorContains(t, err, GitHubToken)
 		})
 
 		t.Run("missing org", func(t *testing.T) {
@@ -156,8 +156,8 @@ func TestInit(t *testing.T) {
 				DiscoveryMechanism: "saml",
 			})
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-			assert.ErrorContains(t, err, GitHubOrg)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorContains(t, err, GitHubOrg)
 		})
 
 		t.Run("missing slug", func(t *testing.T) {
@@ -169,8 +169,8 @@ func TestInit(t *testing.T) {
 				DiscoveryMechanism: "saml",
 			})
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-			assert.ErrorContains(t, err, TeamSlug)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorContains(t, err, TeamSlug)
 		})
 	})
 
@@ -184,7 +184,7 @@ func TestInit(t *testing.T) {
 			DiscoveryMechanism: "foo",
 		})
 
-		assert.ErrorIs(t, err, gosync.ErrMissingConfig)
+		require.ErrorIs(t, err, gosync.ErrMissingConfig)
 	})
 
 	t.Run("with logger", func(t *testing.T) {
@@ -199,7 +199,7 @@ func TestInit(t *testing.T) {
 			DiscoveryMechanism: "saml",
 		}, WithLogger(logger))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, logger, adapter.Logger)
 	})
 
@@ -217,7 +217,7 @@ func TestInit(t *testing.T) {
 			DiscoveryMechanism: "saml",
 		}, WithClient(client))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, client.Teams, adapter.teams)
 	})
 
@@ -232,7 +232,7 @@ func TestInit(t *testing.T) {
 			TeamSlug:    "slug",
 		}, WithDiscoveryService(mockDiscovery))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, mockDiscovery, adapter.discovery)
 	})
 }

--- a/adapters/google/group/group_internal_test.go
+++ b/adapters/google/group/group_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/option"
 
@@ -22,7 +23,7 @@ func withMockAdminService(ctx context.Context, t *testing.T) gosync.ConfigFn[*Gr
 		option.WithScopes(admin.AdminDirectoryGroupMemberScope),
 		option.WithAPIKey("_testing_"),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return func(g *Group) {
 		g.membersService = client.Members
@@ -40,19 +41,19 @@ func (m *mockCalls) callList(
 ) (*admin.Members, error) {
 	args := m.Called(ctx, call, pageToken)
 
-	return args.Get(0).(*admin.Members), args.Error(1) //nolint:wrapcheck
+	return args.Get(0).(*admin.Members), args.Error(1)
 }
 
 func (m *mockCalls) callInsert(ctx context.Context, call *admin.MembersInsertCall) (*admin.Member, error) {
 	args := m.Called(ctx, call)
 
-	return args.Get(0).(*admin.Member), args.Error(1) //nolint:wrapcheck
+	return args.Get(0).(*admin.Member), args.Error(1)
 }
 
 func (m *mockCalls) callDelete(ctx context.Context, call *admin.MembersDeleteCall) error {
 	args := m.Called(ctx, call)
 
-	return args.Error(0) //nolint:wrapcheck
+	return args.Error(0)
 }
 
 func TestGroups_Get(t *testing.T) {
@@ -87,7 +88,7 @@ func TestGroups_Get(t *testing.T) {
 
 	emails, err := group.Get(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"foo@email", "bar@email"}, emails)
 }
 
@@ -114,7 +115,7 @@ func TestGroups_Add(t *testing.T) {
 
 	err := group.Add(ctx, []string{"foo@email", "bar@email"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestGroups_Remove(t *testing.T) {
@@ -140,7 +141,7 @@ func TestGroups_Remove(t *testing.T) {
 
 	err := group.Remove(ctx, []string{"foo@email", "bar@email"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestRole(t *testing.T) {
@@ -169,7 +170,7 @@ func TestRole(t *testing.T) {
 
 	err := group.Add(ctx, []string{"foo@email"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDeliverySettings(t *testing.T) {
@@ -198,10 +199,9 @@ func TestDeliverySettings(t *testing.T) {
 
 	err := group.Add(ctx, []string{"foo@email"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
-//nolint:funlen
 func TestInit(t *testing.T) {
 	t.Parallel()
 
@@ -214,7 +214,7 @@ func TestInit(t *testing.T) {
 			Name: "name",
 		}, withMockAdminService(ctx, t))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.IsType(t, &Group{}, adapter)
 		assert.Equal(t, "name", adapter.name)
 		assert.Equal(t, "", adapter.DeliverySettings)
@@ -229,8 +229,8 @@ func TestInit(t *testing.T) {
 
 			_, err := Init(ctx, map[gosync.ConfigKey]string{}, withMockAdminService(ctx, t))
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-			assert.ErrorContains(t, err, Name)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorContains(t, err, Name)
 		})
 	})
 
@@ -242,7 +242,7 @@ func TestInit(t *testing.T) {
 			Role: "role",
 		}, withMockAdminService(ctx, t))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "role", adapter.Role)
 	})
 
@@ -254,7 +254,7 @@ func TestInit(t *testing.T) {
 			DeliverySettings: "delivery",
 		}, withMockAdminService(ctx, t))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "delivery", adapter.DeliverySettings)
 	})
 
@@ -267,7 +267,7 @@ func TestInit(t *testing.T) {
 			Name: "name",
 		}, withMockAdminService(ctx, t), WithLogger(logger))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, logger, adapter.Logger)
 	})
 
@@ -278,7 +278,7 @@ func TestInit(t *testing.T) {
 			Name: "name",
 		}, withMockAdminService(ctx, t))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, adapter.membersService)
 	})
 }

--- a/adapters/google/group/mock_iMembersService_test.go
+++ b/adapters/google/group/mock_iMembersService_test.go
@@ -24,6 +24,10 @@ func (_m *mockIMembersService) EXPECT() *mockIMembersService_Expecter {
 func (_m *mockIMembersService) Delete(groupKey string, memberKey string) *admin.MembersDeleteCall {
 	ret := _m.Called(groupKey, memberKey)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
 	var r0 *admin.MembersDeleteCall
 	if rf, ok := ret.Get(0).(func(string, string) *admin.MembersDeleteCall); ok {
 		r0 = rf(groupKey, memberKey)
@@ -69,6 +73,10 @@ func (_c *mockIMembersService_Delete_Call) RunAndReturn(run func(string, string)
 func (_m *mockIMembersService) Insert(groupKey string, member *admin.Member) *admin.MembersInsertCall {
 	ret := _m.Called(groupKey, member)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Insert")
+	}
+
 	var r0 *admin.MembersInsertCall
 	if rf, ok := ret.Get(0).(func(string, *admin.Member) *admin.MembersInsertCall); ok {
 		r0 = rf(groupKey, member)
@@ -113,6 +121,10 @@ func (_c *mockIMembersService_Insert_Call) RunAndReturn(run func(string, *admin.
 // List provides a mock function with given fields: groupKey
 func (_m *mockIMembersService) List(groupKey string) *admin.MembersListCall {
 	ret := _m.Called(groupKey)
+
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
 
 	var r0 *admin.MembersListCall
 	if rf, ok := ret.Get(0).(func(string) *admin.MembersListCall); ok {

--- a/adapters/opsgenie/oncall/mock_iOpsgenieSchedule_test.go
+++ b/adapters/opsgenie/oncall/mock_iOpsgenieSchedule_test.go
@@ -26,6 +26,10 @@ func (_m *mockIOpsgenieSchedule) EXPECT() *mockIOpsgenieSchedule_Expecter {
 func (_m *mockIOpsgenieSchedule) GetOnCalls(_a0 context.Context, request *schedule.GetOnCallsRequest) (*schedule.GetOnCallsResult, error) {
 	ret := _m.Called(_a0, request)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetOnCalls")
+	}
+
 	var r0 *schedule.GetOnCallsResult
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *schedule.GetOnCallsRequest) (*schedule.GetOnCallsResult, error)); ok {

--- a/adapters/opsgenie/oncall/oncall_internal_test.go
+++ b/adapters/opsgenie/oncall/oncall_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/schedule"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	gosync "github.com/ovotech/go-sync"
 )
@@ -26,7 +27,7 @@ func createMockedAdapter(ctx context.Context, t *testing.T, mockedTime time.Time
 		OpsgenieAPIKey: "test",
 		ScheduleID:     "test",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	adapter.client = scheduleClient
 	adapter.getTime = func() time.Time {
@@ -59,7 +60,7 @@ func TestOnCall_Get(t *testing.T) {
 
 		emails, err := adapter.Get(ctx)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []string{"foo@email.com", "bar@email.com"}, emails)
 	})
 
@@ -78,7 +79,7 @@ func TestOnCall_Get(t *testing.T) {
 		emails, err := adapter.Get(ctx)
 
 		assert.Nil(t, emails)
-		assert.ErrorContains(t, err, "an example error")
+		require.ErrorContains(t, err, "an example error")
 	})
 }
 
@@ -90,7 +91,7 @@ func TestOnCall_Add(t *testing.T) {
 
 	err := adapter.Add(ctx, []string{"example@bar.com"})
 
-	assert.ErrorIs(t, err, gosync.ErrReadOnly)
+	require.ErrorIs(t, err, gosync.ErrReadOnly)
 	assert.Zero(t, scheduleClient.Calls)
 }
 
@@ -102,11 +103,10 @@ func TestOnCall_Remove(t *testing.T) {
 
 	err := adapter.Remove(ctx, []string{"example@bar.com"})
 
-	assert.ErrorIs(t, err, gosync.ErrReadOnly)
+	require.ErrorIs(t, err, gosync.ErrReadOnly)
 	assert.Zero(t, scheduleClient.Calls)
 }
 
-//nolint:funlen
 func TestInit(t *testing.T) {
 	t.Parallel()
 
@@ -120,7 +120,7 @@ func TestInit(t *testing.T) {
 			ScheduleID:     "schedule",
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.IsType(t, &OnCall{}, adapter)
 		assert.Equal(t, "schedule", adapter.scheduleID)
 	})
@@ -135,8 +135,8 @@ func TestInit(t *testing.T) {
 				ScheduleID: "schedule",
 			})
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-			assert.ErrorContains(t, err, OpsgenieAPIKey)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorContains(t, err, OpsgenieAPIKey)
 		})
 
 		t.Run("missing schedule ID", func(t *testing.T) {
@@ -146,8 +146,8 @@ func TestInit(t *testing.T) {
 				OpsgenieAPIKey: "test",
 			})
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-			assert.ErrorContains(t, err, ScheduleID)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorContains(t, err, ScheduleID)
 		})
 	})
 
@@ -161,7 +161,7 @@ func TestInit(t *testing.T) {
 			ScheduleID:     "schedule",
 		}, WithLogger(logger))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, logger, adapter.Logger)
 	})
 
@@ -171,13 +171,13 @@ func TestInit(t *testing.T) {
 		scheduleClient, err := schedule.NewClient(&client.Config{
 			ApiKey: "test",
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		adapter, err := Init(ctx, map[gosync.ConfigKey]string{
 			ScheduleID: "schedule",
 		}, WithClient(scheduleClient))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, scheduleClient, adapter.client)
 	})
 }

--- a/adapters/opsgenie/schedule/mock_iOpsgenieSchedule_test.go
+++ b/adapters/opsgenie/schedule/mock_iOpsgenieSchedule_test.go
@@ -26,6 +26,10 @@ func (_m *mockIOpsgenieSchedule) EXPECT() *mockIOpsgenieSchedule_Expecter {
 func (_m *mockIOpsgenieSchedule) Get(ctx context.Context, request *opsgenie_go_sdk_v2schedule.GetRequest) (*opsgenie_go_sdk_v2schedule.GetResult, error) {
 	ret := _m.Called(ctx, request)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
+
 	var r0 *opsgenie_go_sdk_v2schedule.GetResult
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *opsgenie_go_sdk_v2schedule.GetRequest) (*opsgenie_go_sdk_v2schedule.GetResult, error)); ok {
@@ -80,6 +84,10 @@ func (_c *mockIOpsgenieSchedule_Get_Call) RunAndReturn(run func(context.Context,
 // UpdateRotation provides a mock function with given fields: ctx, request
 func (_m *mockIOpsgenieSchedule) UpdateRotation(ctx context.Context, request *opsgenie_go_sdk_v2schedule.UpdateRotationRequest) (*opsgenie_go_sdk_v2schedule.UpdateRotationResult, error) {
 	ret := _m.Called(ctx, request)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateRotation")
+	}
 
 	var r0 *opsgenie_go_sdk_v2schedule.UpdateRotationResult
 	var r1 error

--- a/adapters/opsgenie/schedule/schedule_internal_test.go
+++ b/adapters/opsgenie/schedule/schedule_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opsgenie/opsgenie-go-sdk-v2/schedule"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	gosync "github.com/ovotech/go-sync"
 )
@@ -28,7 +29,7 @@ func createMockedAdapter(ctx context.Context, t *testing.T) (*Schedule, *mockIOp
 		OpsgenieAPIKey: "test",
 		ScheduleID:     "test",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	adapter.client = scheduleClient
 
@@ -105,7 +106,7 @@ func testBuildScheduleGetResult(numRotations int, emails ...string) *schedule.Ge
 	}
 }
 
-func TestSchedule_Get(t *testing.T) { //nolint:funlen
+func TestSchedule_Get(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -123,7 +124,7 @@ func TestSchedule_Get(t *testing.T) { //nolint:funlen
 		emails, err := adapter.Get(ctx)
 
 		assert.Nil(t, emails)
-		assert.ErrorContains(t, err, "an example error")
+		require.ErrorContains(t, err, "an example error")
 	})
 
 	t.Run("successful response", func(t *testing.T) {
@@ -138,8 +139,8 @@ func TestSchedule_Get(t *testing.T) { //nolint:funlen
 
 		emails, err := adapter.Get(ctx)
 
-		assert.Nil(t, err)
-		assert.Equal(t, emails, []string{"example1@example.com", "example2@example.com", "example3@example.com"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"example1@example.com", "example2@example.com", "example3@example.com"}, emails)
 	})
 
 	t.Run("should handle multiple rotations", func(t *testing.T) {
@@ -154,8 +155,8 @@ func TestSchedule_Get(t *testing.T) { //nolint:funlen
 
 		emails, err := adapter.Get(ctx)
 
-		assert.Nil(t, err)
-		assert.Equal(t, emails, []string{"example1@example.com", "example2@example.com", "example3@example.com"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"example1@example.com", "example2@example.com", "example3@example.com"}, emails)
 	})
 
 	t.Run("should not duplicate participants across multiple rotations", func(t *testing.T) {
@@ -170,12 +171,12 @@ func TestSchedule_Get(t *testing.T) { //nolint:funlen
 
 		emails, err := adapter.Get(ctx)
 
-		assert.Nil(t, err)
-		assert.Equal(t, emails, []string{"example1@example.com", "example2@example.com", "example3@example.com"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"example1@example.com", "example2@example.com", "example3@example.com"}, emails)
 	})
 }
 
-func TestSchedule_Add(t *testing.T) { //nolint:funlen
+func TestSchedule_Add(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -190,7 +191,7 @@ func TestSchedule_Add(t *testing.T) { //nolint:funlen
 
 		err := adapter.Add(ctx, []string{"example2@example.com"})
 
-		assert.ErrorContains(t, err, "an example error")
+		require.ErrorContains(t, err, "an example error")
 	})
 
 	t.Run("an error should be returned if no rotations exist", func(t *testing.T) {
@@ -202,7 +203,7 @@ func TestSchedule_Add(t *testing.T) { //nolint:funlen
 
 		err := adapter.Add(ctx, []string{"example2@example.com"})
 
-		assert.ErrorContains(t, err, "gosync cannot create rotations")
+		require.ErrorContains(t, err, "gosync cannot create rotations")
 	})
 
 	t.Run("an error should be returned if the schedule has more than 1 rotation", func(t *testing.T) {
@@ -217,7 +218,7 @@ func TestSchedule_Add(t *testing.T) { //nolint:funlen
 
 		err := adapter.Add(ctx, []string{"example2@example.com"})
 
-		assert.ErrorContains(t, err, "gosync can only manage schedules with a single rotation")
+		require.ErrorContains(t, err, "gosync can only manage schedules with a single rotation")
 	})
 
 	t.Run("should add new participants to the rotation", func(t *testing.T) {
@@ -236,7 +237,7 @@ func TestSchedule_Add(t *testing.T) { //nolint:funlen
 
 		err := adapter.Add(ctx, []string{"example3@example.com"})
 
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("should not add duplicates to the rota", func(t *testing.T) {
@@ -252,11 +253,11 @@ func TestSchedule_Add(t *testing.T) { //nolint:funlen
 
 		err := adapter.Add(ctx, []string{"example2@example.com"})
 
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	})
 }
 
-func TestSchedule_Remove(t *testing.T) { //nolint:funlen
+func TestSchedule_Remove(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -271,7 +272,7 @@ func TestSchedule_Remove(t *testing.T) { //nolint:funlen
 
 		err := adapter.Remove(ctx, []string{"example@example.com"})
 
-		assert.ErrorContains(t, err, "an example error")
+		require.ErrorContains(t, err, "an example error")
 	})
 
 	t.Run("an error should be returned if no rotations exist", func(t *testing.T) {
@@ -283,7 +284,7 @@ func TestSchedule_Remove(t *testing.T) { //nolint:funlen
 
 		err := adapter.Remove(ctx, []string{})
 
-		assert.ErrorContains(t, err, "gosync cannot create rotations")
+		require.ErrorContains(t, err, "gosync cannot create rotations")
 	})
 
 	t.Run("an error should be returned if the schedule has more than 1 rotation", func(t *testing.T) {
@@ -295,7 +296,7 @@ func TestSchedule_Remove(t *testing.T) { //nolint:funlen
 
 		err := adapter.Remove(ctx, []string{"example2@example.com"})
 
-		assert.ErrorContains(t, err, "gosync can only manage schedules with a single rotation")
+		require.ErrorContains(t, err, "gosync can only manage schedules with a single rotation")
 	})
 
 	t.Run("should remove existing participants from the rotation", func(t *testing.T) {
@@ -311,7 +312,7 @@ func TestSchedule_Remove(t *testing.T) { //nolint:funlen
 
 		err := adapter.Remove(ctx, []string{"example2@example.com"})
 
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("should ignore nonexistent participants", func(t *testing.T) {
@@ -327,11 +328,10 @@ func TestSchedule_Remove(t *testing.T) { //nolint:funlen
 
 		err := adapter.Remove(ctx, []string{"example3@example.com"})
 
-		assert.Nil(t, err)
+		require.NoError(t, err)
 	})
 }
 
-//nolint:funlen
 func TestInit(t *testing.T) {
 	t.Parallel()
 
@@ -345,7 +345,7 @@ func TestInit(t *testing.T) {
 			ScheduleID:     "schedule",
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.IsType(t, &Schedule{}, adapter)
 		assert.Equal(t, "schedule", adapter.scheduleID)
 	})
@@ -360,8 +360,8 @@ func TestInit(t *testing.T) {
 				ScheduleID: "schedule",
 			})
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-			assert.ErrorContains(t, err, OpsgenieAPIKey)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorContains(t, err, OpsgenieAPIKey)
 		})
 
 		t.Run("missing schedule ID", func(t *testing.T) {
@@ -371,8 +371,8 @@ func TestInit(t *testing.T) {
 				OpsgenieAPIKey: "test",
 			})
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-			assert.ErrorContains(t, err, ScheduleID)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorContains(t, err, ScheduleID)
 		})
 	})
 
@@ -386,7 +386,7 @@ func TestInit(t *testing.T) {
 			ScheduleID:     "schedule",
 		}, WithLogger(logger))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, logger, adapter.Logger)
 	})
 
@@ -396,13 +396,13 @@ func TestInit(t *testing.T) {
 		scheduleClient, err := schedule.NewClient(&client.Config{
 			ApiKey: "test",
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		adapter, err := Init(ctx, map[gosync.ConfigKey]string{
 			ScheduleID: "schedule",
 		}, WithClient(scheduleClient))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, scheduleClient, adapter.client)
 	})
 }

--- a/adapters/slack/conversation/conversation_internal_test.go
+++ b/adapters/slack/conversation/conversation_internal_test.go
@@ -3,13 +3,14 @@ package conversation
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	gosync "github.com/ovotech/go-sync"
 )
@@ -63,7 +64,7 @@ func TestConversation_Get(t *testing.T) {
 
 	accounts, err := adapter.Get(context.TODO())
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, accounts, []string{"foo@email", "bar@email"})
 	assert.Equal(t, map[string]string{"foo@email": "foo", "bar@email": "bar"}, adapter.cache)
 }
@@ -86,17 +87,17 @@ func TestConversation_Get_Pagination(t *testing.T) {
 	secondResponse := make([]slack.User, 30)
 
 	for idx := range incrementingSlice {
-		incrementingSlice[idx] = fmt.Sprint(idx)
+		incrementingSlice[idx] = strconv.Itoa(idx)
 
 		if idx < 30 {
-			firstPage[idx] = fmt.Sprint(idx)
+			firstPage[idx] = strconv.Itoa(idx)
 			firstResponse[idx] = slack.User{
-				ID: fmt.Sprint(idx), IsBot: false, Profile: slack.UserProfile{Email: fmt.Sprint(idx)},
+				ID: strconv.Itoa(idx), IsBot: false, Profile: slack.UserProfile{Email: strconv.Itoa(idx)},
 			}
 		} else {
-			secondPage[idx-30] = fmt.Sprint(idx)
+			secondPage[idx-30] = strconv.Itoa(idx)
 			secondResponse[idx-30] = slack.User{
-				ID: fmt.Sprint(idx), IsBot: false, Profile: slack.UserProfile{Email: fmt.Sprint(idx)},
+				ID: strconv.Itoa(idx), IsBot: false, Profile: slack.UserProfile{Email: strconv.Itoa(idx)},
 			}
 		}
 	}
@@ -112,7 +113,7 @@ func TestConversation_Get_Pagination(t *testing.T) {
 
 	_, err := adapter.Get(context.TODO())
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestConversation_Add(t *testing.T) {
@@ -136,10 +137,9 @@ func TestConversation_Add(t *testing.T) {
 
 	err := adapter.Add(context.TODO(), []string{"foo@email", "bar@email"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
-//nolint:funlen
 func TestConversation_Remove(t *testing.T) {
 	t.Parallel()
 
@@ -162,7 +162,7 @@ func TestConversation_Remove(t *testing.T) {
 
 		err := adapter.Remove(ctx, []string{"foo@email", "bar@email"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Restricted kick from public conversation", func(t *testing.T) {
@@ -185,14 +185,14 @@ func TestConversation_Remove(t *testing.T) {
 
 		err := adapter.Remove(ctx, []string{"foo@email", "bar@email"})
 
-		assert.Error(t, err)
-		assert.ErrorIs(t, err, restrictedAction)
+		require.Error(t, err)
+		require.ErrorIs(t, err, restrictedAction)
 
 		adapter.MuteRestrictedErrOnKickFromPublic = true
 
 		err = adapter.Remove(ctx, []string{"foo@email", "bar@email"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Check case sensitivity", func(t *testing.T) {
@@ -226,11 +226,10 @@ func TestConversation_Remove(t *testing.T) {
 		// Capitalise the first letter of each email.
 		err := adapter.Remove(ctx, []string{"Foo@email", "Bar@email"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
-//nolint:funlen
 func TestInit(t *testing.T) {
 	t.Parallel()
 
@@ -244,7 +243,7 @@ func TestInit(t *testing.T) {
 			Name:        "conversation",
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.IsType(t, &Conversation{}, adapter)
 		assert.Equal(t, "conversation", adapter.conversationName)
 		assert.False(t, adapter.MuteRestrictedErrOnKickFromPublic)
@@ -260,8 +259,8 @@ func TestInit(t *testing.T) {
 				Name: "conversation",
 			})
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-			assert.ErrorContains(t, err, SlackAPIKey)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorContains(t, err, SlackAPIKey)
 		})
 
 		t.Run("missing name", func(t *testing.T) {
@@ -271,8 +270,8 @@ func TestInit(t *testing.T) {
 				SlackAPIKey: "test",
 			})
 
-			assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-			assert.ErrorContains(t, err, Name)
+			require.ErrorIs(t, err, gosync.ErrMissingConfig)
+			require.ErrorContains(t, err, Name)
 		})
 
 		t.Run("MuteRestrictedErrOnKickFromPublic", func(t *testing.T) {
@@ -285,7 +284,7 @@ func TestInit(t *testing.T) {
 					MuteRestrictedErrOnKickFromPublic: test,
 				})
 
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.False(t, adapter.MuteRestrictedErrOnKickFromPublic, test)
 			}
 
@@ -296,7 +295,7 @@ func TestInit(t *testing.T) {
 					MuteRestrictedErrOnKickFromPublic: test,
 				})
 
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.True(t, adapter.MuteRestrictedErrOnKickFromPublic, test)
 			}
 		})
@@ -312,7 +311,7 @@ func TestInit(t *testing.T) {
 			Name:        "conversation",
 		}, WithLogger(logger))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, logger, adapter.Logger)
 	})
 
@@ -325,7 +324,7 @@ func TestInit(t *testing.T) {
 			Name: "conversation",
 		}, WithClient(client))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, client, adapter.client)
 	})
 }

--- a/adapters/slack/conversation/mock_iSlackConversation_test.go
+++ b/adapters/slack/conversation/mock_iSlackConversation_test.go
@@ -24,6 +24,10 @@ func (_m *mockISlackConversation) EXPECT() *mockISlackConversation_Expecter {
 func (_m *mockISlackConversation) GetUserByEmail(email string) (*slack.User, error) {
 	ret := _m.Called(email)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserByEmail")
+	}
+
 	var r0 *slack.User
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (*slack.User, error)); ok {
@@ -77,6 +81,10 @@ func (_c *mockISlackConversation_GetUserByEmail_Call) RunAndReturn(run func(stri
 // GetUsersInConversation provides a mock function with given fields: params
 func (_m *mockISlackConversation) GetUsersInConversation(params *slack.GetUsersInConversationParameters) ([]string, string, error) {
 	ret := _m.Called(params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsersInConversation")
+	}
 
 	var r0 []string
 	var r1 string
@@ -144,6 +152,10 @@ func (_m *mockISlackConversation) GetUsersInfo(users ...string) (*[]slack.User, 
 	var _ca []interface{}
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsersInfo")
+	}
 
 	var r0 *[]slack.User
 	var r1 error
@@ -213,6 +225,10 @@ func (_m *mockISlackConversation) InviteUsersToConversation(channelID string, us
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for InviteUsersToConversation")
+	}
+
 	var r0 *slack.Channel
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string, ...string) (*slack.Channel, error)); ok {
@@ -274,6 +290,10 @@ func (_c *mockISlackConversation_InviteUsersToConversation_Call) RunAndReturn(ru
 // KickUserFromConversation provides a mock function with given fields: channelID, user
 func (_m *mockISlackConversation) KickUserFromConversation(channelID string, user string) error {
 	ret := _m.Called(channelID, user)
+
+	if len(ret) == 0 {
+		panic("no return value specified for KickUserFromConversation")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string) error); ok {

--- a/adapters/slack/usergroup/mock_iSlackUserGroup_test.go
+++ b/adapters/slack/usergroup/mock_iSlackUserGroup_test.go
@@ -26,6 +26,10 @@ func (_m *mockISlackUserGroup) EXPECT() *mockISlackUserGroup_Expecter {
 func (_m *mockISlackUserGroup) GetUserByEmailContext(ctx context.Context, email string) (*slack.User, error) {
 	ret := _m.Called(ctx, email)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserByEmailContext")
+	}
+
 	var r0 *slack.User
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) (*slack.User, error)); ok {
@@ -80,6 +84,10 @@ func (_c *mockISlackUserGroup_GetUserByEmailContext_Call) RunAndReturn(run func(
 // GetUserGroupMembersContext provides a mock function with given fields: ctx, userGroup
 func (_m *mockISlackUserGroup) GetUserGroupMembersContext(ctx context.Context, userGroup string) ([]string, error) {
 	ret := _m.Called(ctx, userGroup)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserGroupMembersContext")
+	}
 
 	var r0 []string
 	var r1 error
@@ -143,6 +151,10 @@ func (_m *mockISlackUserGroup) GetUsersInfoContext(ctx context.Context, users ..
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsersInfoContext")
+	}
+
 	var r0 *[]slack.User
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, ...string) (*[]slack.User, error)); ok {
@@ -204,6 +216,10 @@ func (_c *mockISlackUserGroup_GetUsersInfoContext_Call) RunAndReturn(run func(co
 // UpdateUserGroupMembersContext provides a mock function with given fields: ctx, userGroup, members
 func (_m *mockISlackUserGroup) UpdateUserGroupMembersContext(ctx context.Context, userGroup string, members string) (slack.UserGroup, error) {
 	ret := _m.Called(ctx, userGroup, members)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateUserGroupMembersContext")
+	}
 
 	var r0 slack.UserGroup
 	var r1 error

--- a/adapters/terraformcloud/membership/membership_integration_test.go
+++ b/adapters/terraformcloud/membership/membership_integration_test.go
@@ -26,23 +26,23 @@ func TestIntegration(t *testing.T) {
 		membership.Token:        *token,
 		membership.Organisation: *organisation,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create a membership
 	err = adapter.Add(ctx, []string{*email})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Assert the membership has been created
 	members, err := adapter.Get(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, members, *email)
 
 	// Delete the membership
 	err = adapter.Remove(ctx, []string{*email})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Assert the membership has been deleted
 	members, err = adapter.Get(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotContains(t, members, *email)
 }

--- a/adapters/terraformcloud/membership/membership_internal_test.go
+++ b/adapters/terraformcloud/membership/membership_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	gosync "github.com/ovotech/go-sync"
 )
@@ -58,7 +59,7 @@ func TestMembership_Get(t *testing.T) {
 
 	things, err := adapter.Get(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, things, []string{
 		"foo@email",
 		"bar@email",
@@ -89,7 +90,7 @@ func TestMembership_Add(t *testing.T) {
 	}, nil)
 
 	err := adapter.Add(ctx, []string{"foo@email"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestMembership_Remove(t *testing.T) {
@@ -122,7 +123,7 @@ func TestMembership_Remove(t *testing.T) {
 
 	err := adapter.Remove(ctx, []string{"foo@email"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestInit(t *testing.T) {
@@ -138,7 +139,7 @@ func TestInit(t *testing.T) {
 			Organisation: "org",
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.IsType(t, &Membership{}, adapter)
 	})
 
@@ -149,7 +150,7 @@ func TestInit(t *testing.T) {
 			Token: "token",
 		})
 
-		assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-		assert.ErrorContains(t, err, Organisation)
+		require.ErrorIs(t, err, gosync.ErrMissingConfig)
+		require.ErrorContains(t, err, Organisation)
 	})
 }

--- a/adapters/terraformcloud/membership/mock_iOrganizationMemberships_test.go
+++ b/adapters/terraformcloud/membership/mock_iOrganizationMemberships_test.go
@@ -26,6 +26,10 @@ func (_m *mockIOrganizationMemberships) EXPECT() *mockIOrganizationMemberships_E
 func (_m *mockIOrganizationMemberships) Create(ctx context.Context, organization string, options tfe.OrganizationMembershipCreateOptions) (*tfe.OrganizationMembership, error) {
 	ret := _m.Called(ctx, organization, options)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Create")
+	}
+
 	var r0 *tfe.OrganizationMembership
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, tfe.OrganizationMembershipCreateOptions) (*tfe.OrganizationMembership, error)); ok {
@@ -82,6 +86,10 @@ func (_c *mockIOrganizationMemberships_Create_Call) RunAndReturn(run func(contex
 func (_m *mockIOrganizationMemberships) Delete(ctx context.Context, organizationMembershipID string) error {
 	ret := _m.Called(ctx, organizationMembershipID)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(ctx, organizationMembershipID)
@@ -124,6 +132,10 @@ func (_c *mockIOrganizationMemberships_Delete_Call) RunAndReturn(run func(contex
 // List provides a mock function with given fields: ctx, organization, options
 func (_m *mockIOrganizationMemberships) List(ctx context.Context, organization string, options *tfe.OrganizationMembershipListOptions) (*tfe.OrganizationMembershipList, error) {
 	ret := _m.Called(ctx, organization, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
 
 	var r0 *tfe.OrganizationMembershipList
 	var r1 error
@@ -180,6 +192,10 @@ func (_c *mockIOrganizationMemberships_List_Call) RunAndReturn(run func(context.
 // Read provides a mock function with given fields: ctx, organizationMembershipID
 func (_m *mockIOrganizationMemberships) Read(ctx context.Context, organizationMembershipID string) (*tfe.OrganizationMembership, error) {
 	ret := _m.Called(ctx, organizationMembershipID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Read")
+	}
 
 	var r0 *tfe.OrganizationMembership
 	var r1 error

--- a/adapters/terraformcloud/team/mock_iTeams_test.go
+++ b/adapters/terraformcloud/team/mock_iTeams_test.go
@@ -26,6 +26,10 @@ func (_m *mockITeams) EXPECT() *mockITeams_Expecter {
 func (_m *mockITeams) Create(ctx context.Context, organization string, options tfe.TeamCreateOptions) (*tfe.Team, error) {
 	ret := _m.Called(ctx, organization, options)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Create")
+	}
+
 	var r0 *tfe.Team
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, tfe.TeamCreateOptions) (*tfe.Team, error)); ok {
@@ -82,6 +86,10 @@ func (_c *mockITeams_Create_Call) RunAndReturn(run func(context.Context, string,
 func (_m *mockITeams) Delete(ctx context.Context, teamID string) error {
 	ret := _m.Called(ctx, teamID)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(ctx, teamID)
@@ -124,6 +132,10 @@ func (_c *mockITeams_Delete_Call) RunAndReturn(run func(context.Context, string)
 // List provides a mock function with given fields: ctx, organization, options
 func (_m *mockITeams) List(ctx context.Context, organization string, options *tfe.TeamListOptions) (*tfe.TeamList, error) {
 	ret := _m.Called(ctx, organization, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
 
 	var r0 *tfe.TeamList
 	var r1 error

--- a/adapters/terraformcloud/team/team_internal_test.go
+++ b/adapters/terraformcloud/team/team_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	gosync "github.com/ovotech/go-sync"
 )
@@ -49,7 +50,7 @@ func TestTeam_Get(t *testing.T) {
 
 	things, err := adapter.Get(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, things, []string{"foo", "bar", "fizz", "buzz"})
 }
 
@@ -72,7 +73,7 @@ func TestTeam_Add(t *testing.T) {
 
 	err := adapter.Add(ctx, []string{"foo"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestTeam_Remove(t *testing.T) {
@@ -93,7 +94,7 @@ func TestTeam_Remove(t *testing.T) {
 
 	err := adapter.Remove(ctx, []string{"foo"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestInit(t *testing.T) {
@@ -106,7 +107,7 @@ func TestInit(t *testing.T) {
 
 		adapter, err := Init(ctx, map[gosync.ConfigKey]string{Token: "token", Organisation: "org"})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.IsType(t, &Team{}, adapter)
 	})
 
@@ -115,8 +116,8 @@ func TestInit(t *testing.T) {
 
 		_, err := Init(ctx, map[gosync.ConfigKey]string{Organisation: "org"})
 
-		assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-		assert.ErrorContains(t, err, Token)
+		require.ErrorIs(t, err, gosync.ErrMissingConfig)
+		require.ErrorContains(t, err, Token)
 	})
 
 	t.Run("missing organisation", func(t *testing.T) {
@@ -124,8 +125,8 @@ func TestInit(t *testing.T) {
 
 		_, err := Init(ctx, map[gosync.ConfigKey]string{Token: "token"})
 
-		assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-		assert.ErrorContains(t, err, Organisation)
+		require.ErrorIs(t, err, gosync.ErrMissingConfig)
+		require.ErrorContains(t, err, Organisation)
 	})
 
 	t.Run("with logger", func(t *testing.T) {
@@ -138,7 +139,7 @@ func TestInit(t *testing.T) {
 			Organisation: "org",
 		}, WithLogger(logger))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, logger, adapter.Logger)
 	})
 
@@ -146,13 +147,13 @@ func TestInit(t *testing.T) {
 		t.Parallel()
 
 		client, err := tfe.NewClient(&tfe.Config{Token: "test"})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		adapter, err := Init(ctx, map[gosync.ConfigKey]string{
 			Organisation: "org",
 		}, WithClient(client))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, client.Teams, adapter.teams)
 	})
 }

--- a/adapters/terraformcloud/user/mock_iOrganizationMemberships_test.go
+++ b/adapters/terraformcloud/user/mock_iOrganizationMemberships_test.go
@@ -26,6 +26,10 @@ func (_m *mockIOrganizationMemberships) EXPECT() *mockIOrganizationMemberships_E
 func (_m *mockIOrganizationMemberships) List(ctx context.Context, organization string, options *tfe.OrganizationMembershipListOptions) (*tfe.OrganizationMembershipList, error) {
 	ret := _m.Called(ctx, organization, options)
 
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
+
 	var r0 *tfe.OrganizationMembershipList
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, *tfe.OrganizationMembershipListOptions) (*tfe.OrganizationMembershipList, error)); ok {

--- a/adapters/terraformcloud/user/mock_iTeamMembers_test.go
+++ b/adapters/terraformcloud/user/mock_iTeamMembers_test.go
@@ -26,6 +26,10 @@ func (_m *mockITeamMembers) EXPECT() *mockITeamMembers_Expecter {
 func (_m *mockITeamMembers) Add(ctx context.Context, teamID string, options tfe.TeamMemberAddOptions) error {
 	ret := _m.Called(ctx, teamID, options)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Add")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, tfe.TeamMemberAddOptions) error); ok {
 		r0 = rf(ctx, teamID, options)
@@ -69,6 +73,10 @@ func (_c *mockITeamMembers_Add_Call) RunAndReturn(run func(context.Context, stri
 // List provides a mock function with given fields: ctx, teamID
 func (_m *mockITeamMembers) List(ctx context.Context, teamID string) ([]*tfe.User, error) {
 	ret := _m.Called(ctx, teamID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
 
 	var r0 []*tfe.User
 	var r1 error
@@ -124,6 +132,10 @@ func (_c *mockITeamMembers_List_Call) RunAndReturn(run func(context.Context, str
 // Remove provides a mock function with given fields: ctx, teamID, options
 func (_m *mockITeamMembers) Remove(ctx context.Context, teamID string, options tfe.TeamMemberRemoveOptions) error {
 	ret := _m.Called(ctx, teamID, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Remove")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, tfe.TeamMemberRemoveOptions) error); ok {

--- a/adapters/terraformcloud/user/mock_iTeams_test.go
+++ b/adapters/terraformcloud/user/mock_iTeams_test.go
@@ -26,6 +26,10 @@ func (_m *mockITeams) EXPECT() *mockITeams_Expecter {
 func (_m *mockITeams) List(ctx context.Context, organization string, options *tfe.TeamListOptions) (*tfe.TeamList, error) {
 	ret := _m.Called(ctx, organization, options)
 
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
+
 	var r0 *tfe.TeamList
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, *tfe.TeamListOptions) (*tfe.TeamList, error)); ok {

--- a/adapters/terraformcloud/user/user_internal_test.go
+++ b/adapters/terraformcloud/user/user_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	gosync "github.com/ovotech/go-sync"
 )
@@ -44,7 +45,7 @@ func TestUser_Get(t *testing.T) {
 
 	things, err := adapter.Get(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, things, []string{"foo@email", "bar@email"})
 }
 
@@ -108,7 +109,7 @@ func TestUser_Add(t *testing.T) {
 
 	err := adapter.Add(ctx, []string{"foo@email", "bar@email"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUser_Remove(t *testing.T) {
@@ -155,10 +156,9 @@ func TestUser_Remove(t *testing.T) {
 
 	err := adapter.Remove(ctx, []string{"foo@email"})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
-//nolint:funlen
 func TestInit(t *testing.T) {
 	t.Parallel()
 
@@ -173,7 +173,7 @@ func TestInit(t *testing.T) {
 			Team:         "team",
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.IsType(t, &User{}, adapter)
 	})
 
@@ -185,8 +185,8 @@ func TestInit(t *testing.T) {
 			Team:         "team",
 		})
 
-		assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-		assert.ErrorContains(t, err, Token)
+		require.ErrorIs(t, err, gosync.ErrMissingConfig)
+		require.ErrorContains(t, err, Token)
 	})
 
 	t.Run("missing organisation", func(t *testing.T) {
@@ -197,8 +197,8 @@ func TestInit(t *testing.T) {
 			Team:  "team",
 		})
 
-		assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-		assert.ErrorContains(t, err, Organisation)
+		require.ErrorIs(t, err, gosync.ErrMissingConfig)
+		require.ErrorContains(t, err, Organisation)
 	})
 
 	t.Run("missing team", func(t *testing.T) {
@@ -209,8 +209,8 @@ func TestInit(t *testing.T) {
 			Organisation: "org",
 		})
 
-		assert.ErrorIs(t, err, gosync.ErrMissingConfig)
-		assert.ErrorContains(t, err, Team)
+		require.ErrorIs(t, err, gosync.ErrMissingConfig)
+		require.ErrorContains(t, err, Team)
 	})
 
 	t.Run("with logger", func(t *testing.T) {
@@ -224,7 +224,7 @@ func TestInit(t *testing.T) {
 			Team:         "team",
 		}, WithLogger(logger))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, logger, adapter.Logger)
 	})
 
@@ -232,14 +232,14 @@ func TestInit(t *testing.T) {
 		t.Parallel()
 
 		client, err := tfe.NewClient(&tfe.Config{Token: "test"})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		adapter, err := Init(ctx, map[gosync.ConfigKey]string{
 			Organisation: "org",
 			Team:         "team",
 		}, WithClient(client))
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, client.Teams, adapter.teams)
 		assert.Equal(t, client.TeamMembers, adapter.teamMembers)
 		assert.Equal(t, client.OrganizationMemberships, adapter.organizationMemberships)

--- a/mock_Adapter_test.go
+++ b/mock_Adapter_test.go
@@ -25,6 +25,10 @@ func (_m *MockAdapter) EXPECT() *MockAdapter_Expecter {
 func (_m *MockAdapter) Add(ctx context.Context, things []string) error {
 	ret := _m.Called(ctx, things)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Add")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, []string) error); ok {
 		r0 = rf(ctx, things)
@@ -67,6 +71,10 @@ func (_c *MockAdapter_Add_Call) RunAndReturn(run func(context.Context, []string)
 // Get provides a mock function with given fields: ctx
 func (_m *MockAdapter) Get(ctx context.Context) ([]string, error) {
 	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
 
 	var r0 []string
 	var r1 error
@@ -121,6 +129,10 @@ func (_c *MockAdapter_Get_Call) RunAndReturn(run func(context.Context) ([]string
 // Remove provides a mock function with given fields: ctx, things
 func (_m *MockAdapter) Remove(ctx context.Context, things []string) error {
 	ret := _m.Called(ctx, things)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Remove")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, []string) error); ok {

--- a/mock_InitFn_test.go
+++ b/mock_InitFn_test.go
@@ -32,6 +32,10 @@ func (_m *MockInitFn[T]) Execute(_a0 context.Context, _a1 map[string]string, _a2
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Execute")
+	}
+
 	var r0 T
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, map[string]string, ...ConfigFn[T]) (T, error)); ok {

--- a/mock_Service_test.go
+++ b/mock_Service_test.go
@@ -25,6 +25,10 @@ func (_m *MockService) EXPECT() *MockService_Expecter {
 func (_m *MockService) SyncWith(ctx context.Context, adapter Adapter) error {
 	ret := _m.Called(ctx, adapter)
 
+	if len(ret) == 0 {
+		panic("no return value specified for SyncWith")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, Adapter) error); ok {
 		r0 = rf(ctx, adapter)

--- a/sync_internal_test.go
+++ b/sync_internal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -21,7 +22,6 @@ func TestNew(t *testing.T) {
 	assert.Zero(t, adapter.Calls)
 }
 
-//nolint:funlen
 func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 	t.Parallel()
 
@@ -45,7 +45,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 
 		t.Run("Add failure", func(t *testing.T) {
@@ -65,8 +65,8 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.Error(t, err)
-			assert.ErrorIs(t, err, testErr)
+			require.Error(t, err)
+			require.ErrorIs(t, err, testErr)
 		})
 
 		t.Run("Add error get", func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.ErrorIs(t, err, testErr)
+			require.ErrorIs(t, err, testErr)
 		})
 	})
 
@@ -107,7 +107,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 
 		t.Run("Remove failure", func(t *testing.T) {
@@ -127,8 +127,8 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.Error(t, err)
-			assert.ErrorIs(t, err, testErr)
+			require.Error(t, err)
+			require.ErrorIs(t, err, testErr)
 		})
 
 		t.Run("Remove error get", func(t *testing.T) {
@@ -146,7 +146,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.ErrorIs(t, err, testErr)
+			require.ErrorIs(t, err, testErr)
 		})
 
 		t.Run("Remove error remove", func(t *testing.T) {
@@ -166,7 +166,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.ErrorIs(t, err, testErr)
+			require.ErrorIs(t, err, testErr)
 		})
 	})
 
@@ -187,7 +187,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 		err := syncService.SyncWith(ctx, destination)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("DryRun", func(t *testing.T) {
@@ -206,7 +206,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 			destination.EXPECT().Get(ctx).Once().Return([]string{}, nil)
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 
 		t.Run("Remove", func(t *testing.T) {
@@ -222,7 +222,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 			destination.EXPECT().Get(ctx).Once().Return([]string{"foo", "bar"}, nil)
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	})
 
@@ -239,7 +239,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 		err := syncService.SyncWith(ctx, destination)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("OperatingMode", func(t *testing.T) {
@@ -260,7 +260,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 
 		t.Run("RemoveOnly", func(t *testing.T) {
@@ -278,7 +278,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 
 		t.Run("RemoveAdd", func(t *testing.T) { //nolint:dupl
@@ -297,7 +297,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, "Get", destination.Calls[0].Method)
 			assert.Equal(t, "Remove", destination.Calls[1].Method)
 			assert.Equal(t, "Add", destination.Calls[2].Method)
@@ -319,7 +319,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, "Get", destination.Calls[0].Method)
 			assert.Equal(t, "Add", destination.Calls[1].Method)
 			assert.Equal(t, "Remove", destination.Calls[2].Method)
@@ -354,7 +354,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 
 		t.Run("false", func(t *testing.T) {
@@ -372,7 +372,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	})
 
@@ -395,7 +395,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.ErrorIs(t, err, ErrTooManyChanges)
+			require.ErrorIs(t, err, ErrTooManyChanges)
 		})
 
 		t.Run("1", func(t *testing.T) {
@@ -406,14 +406,14 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.ErrorIs(t, err, ErrTooManyChanges)
+			require.ErrorIs(t, err, ErrTooManyChanges)
 
 			// Set the operating mode to Remove only (only 1 addition), which should pass successfully.
 			syncService.OperatingMode = RemoveOnly
 
 			err = syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 
 		t.Run("2", func(t *testing.T) {
@@ -424,7 +424,7 @@ func TestSync_SyncWith(t *testing.T) { //nolint:maintidx
 
 			err := syncService.SyncWith(ctx, destination)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	})
 }


### PR DESCRIPTION
The latest version of `golangci-lint` makes some critical changes to the linters, so I've fixed the various errors across multiple files.