### PR TITLE
Only Update Slack User Group via Slack API when Membership changes

### DIFF
--- a/adapters/slack/usergroup/usergroup.go
+++ b/adapters/slack/usergroup/usergroup.go
@@ -45,7 +45,6 @@ import (
 	"log"
 	"math"
 	"os"
-	"slices"
 	"strings"
 	"time"
 
@@ -186,7 +185,8 @@ func (u *UserGroup) Add(ctx context.Context, emails []string) error {
 			return fmt.Errorf("slack.usergroup.add.getuserbyemail(%s) -> %w", email, err)
 		}
 
-		if !(slices.Contains(updatedUserGroup, user.ID)) {
+		_, ok := u.cache[email]
+		if !ok {
 			// Add the new email user IDs to the list.
 			updatedUserGroup = append(updatedUserGroup, user.ID)
 


### PR DESCRIPTION
Prevent calling Slack API if usergroup membership doesn't change

My team were seeing an issue where syncing an OpsGenie Rota to a Slack UserGroup caused the members to be notified every time the sync ran even if membership didn't change. I believe the issue is with Slack so this is a workaround for that.